### PR TITLE
FEAT: Save map center and zoom when changed

### DIFF
--- a/src/components/FeaturedPlaces.tsx
+++ b/src/components/FeaturedPlaces.tsx
@@ -57,7 +57,6 @@ const FeaturedPlaces = () => {
       if (typesResults.error) {
         console.error(`Fail to fetch types by category id ${id}`)
       }
-      console.log(typesResults)
       setSpots(typesResults.data?.spots || [])
     },
     [getSpots]

--- a/src/components/organisms/CategorySelector.tsx
+++ b/src/components/organisms/CategorySelector.tsx
@@ -23,7 +23,6 @@ const CategorySelector: React.FC<Props> = ({ onChange: changedCallback }) => {
   const id = open ? 'simple-popper' : undefined
 
   const handleClick = (event: React.MouseEvent<HTMLElement>) => {
-    console.log(event.currentTarget)
     setAnchorEl(anchorEl ? null : event.currentTarget)
   }
 

--- a/src/hooks/usePlaces.ts
+++ b/src/hooks/usePlaces.ts
@@ -22,7 +22,6 @@ export const usePlaces = () => {
               reject(new Error('Fail to connect google maps api'))
             }
 
-            console.log(result)
             resolve(result?.photos?.map(item => item.getUrl()) || [])
           }
         )


### PR DESCRIPTION
close #24 

- Spot を選択したときにマップがデフォルトの位置に移動する問題を修正
- Map の Center と Zoom が変化したときにその値を State に保存するように変更
- Center の変化後0.5秒待機することで、Drag 後の滑りを再現した