### PR TITLE
Feat/46 move day

### DIFF
--- a/src/components/organisms/PlanEditor.tsx
+++ b/src/components/organisms/PlanEditor.tsx
@@ -117,22 +117,30 @@ const PlanEditor = () => {
   }
 
   const handleEventDrop = (e: EventDropArg) => {
+    console.log(e)
     eventsApi.update(e.event.toJSON() as SpotEvent)
 
     if (e.event.end && e.oldEvent.end) {
-      events
-        .filter(
-          (event) =>
-            dayjs(event.start).date() === dayjs(e.oldEvent.end).date() &&
-            event.id !== e.event.id
-        )
-        .forEach((event) => {
-          eventsApi.update({
-            ...event,
-            start: dayjs(event.start).add(e.delta.milliseconds, 'ms').toDate(),
-            end: dayjs(event.end).add(e.delta.milliseconds, 'ms').toDate(),
+      console.log(Math.abs(e.event.end.getDate() - e.oldEvent.end.getDate()))
+      if (Math.abs(e.event.end.getDate() - e.oldEvent.end.getDate()) >= 1) {
+        console.log('Move day')
+      } else {
+        events
+          .filter(
+            (event) =>
+              dayjs(event.start).date() === dayjs(e.oldEvent.end).date() &&
+              event.id !== e.event.id
+          )
+          .forEach((event) => {
+            eventsApi.update({
+              ...event,
+              start: dayjs(event.start)
+                .add(e.delta.milliseconds, 'ms')
+                .toDate(),
+              end: dayjs(event.end).add(e.delta.milliseconds, 'ms').toDate(),
+            })
           })
-        })
+      }
     }
   }
 

--- a/src/contexts/SelectedPlacesProvider.tsx
+++ b/src/contexts/SelectedPlacesProvider.tsx
@@ -8,14 +8,14 @@ export type Move = { type: 'move'; from: string; to: string }
 type CustomEventInput = Omit<EventInput, 'extendedProps'>
 export type SpotEvent = CustomEventInput & {
   id: string
-  start: Date
-  end: Date
+  start: Date | string
+  end: Date | string
   extendedProps: Spot
 }
 export type MoveEvent = CustomEventInput & {
   id: string
-  start: Date
-  end: Date
+  start: Date | string
+  end: Date | string
   extendedProps: Move
 }
 


### PR DESCRIPTION
close #46

- Spot イベントの日付間移動を実装
  - 日付を跨いだ移動をすると、以下の処理が行われる
    - 元の日付の関連する Move イベントを更新
      - 直前の移動を削除
      - 次のスポットがある場合は直前のスポットからの移動に更新
    - 移動先のMoveイベントを更新
      - 直前のイベントからのMove イベントを追加
      - 直後のイベントへの Move イベントを追加
      - 移動先に Move イベントがある場合は削除する