### PR TITLE
Feat/47 remove event

### DIFF
--- a/src/components/organisms/EventToolbar.tsx
+++ b/src/components/organisms/EventToolbar.tsx
@@ -12,7 +12,11 @@ import { EventApi } from '@fullcalendar/react'
 
 import { useDistanceMatrix } from 'hooks/useDistanceMatrix'
 import { useSelectSpots } from 'hooks/useSelectSpots'
-import { MoveEvent, SpotEvent } from 'contexts/SelectedPlacesProvider'
+import {
+  MoveEvent,
+  ScheduleEvent,
+  SpotEvent,
+} from 'contexts/SelectedPlacesProvider'
 import dayjs from 'dayjs'
 
 type Props = {
@@ -294,7 +298,7 @@ const EventToolbar: React.FC<Props> = ({ event }) => {
   }
 
   const handleRemove = () => {
-    spotsApi.remove(event.id)
+    spotsApi.remove(event.toJSON() as ScheduleEvent)
   }
 
   return (

--- a/src/components/organisms/PlanEditor.tsx
+++ b/src/components/organisms/PlanEditor.tsx
@@ -136,7 +136,7 @@ const PlanEditor = () => {
         )
         const beforeSpotId = beforeMove?.extendedProps.from
         if (beforeSpotId) {
-          eventsApi.remove(beforeMove.id)
+          eventsApi.remove(beforeMove)
         }
         // update after move if exists
         const afterMove = events.find(
@@ -201,7 +201,7 @@ const PlanEditor = () => {
             applyChange(afterMove)
           } else {
             // Remove move event if previous spot is not exists
-            eventsApi.remove(afterMove.id)
+            eventsApi.remove(afterMove)
           }
         }
 

--- a/src/components/organisms/PlanEditor.tsx
+++ b/src/components/organisms/PlanEditor.tsx
@@ -102,6 +102,9 @@ const PlanEditor = () => {
   const gridWidth = daysDuration * 300
 
   const handleEventsSet = (_events: EventApi[]) => {
+    if (_events.length === 0) {
+      return
+    }
     const days = _events.map((e) => dayjs(e.start))
     const sorted = days.sort((a, b) => a.diff(b))
     const first = sorted[0]

--- a/src/components/organisms/SpotCard.tsx
+++ b/src/components/organisms/SpotCard.tsx
@@ -12,7 +12,10 @@ import { faInstagram } from '@fortawesome/free-brands-svg-icons'
 
 import { useGetSpotByPkLazyQuery } from 'generated/graphql'
 import { usePlaces } from 'hooks/usePlaces'
-import { SelectedPlacesContext, SpotEvent } from 'contexts/SelectedPlacesProvider'
+import {
+  SelectedPlacesContext,
+  SpotEvent,
+} from 'contexts/SelectedPlacesProvider'
 import { useSelectSpots } from 'hooks/useSelectSpots'
 
 type ButtonProps = {
@@ -31,7 +34,7 @@ const SelectButton: React.FC<ButtonProps> = ({ placeId, photo }) => {
 
   const handleClick = () => {
     if (selected) {
-      actions.remove(selected.id)
+      actions.remove(selected)
     } else {
       actions.add({ placeId, imageUrl: photo })
     }


### PR DESCRIPTION
Close #47 

- スポットイベントを削除する際に、Move イベントも削除するようにした
- 削除方法は 日付間移動をするときと同じ

- Event が 0 個のときに例外が発生するのを防止