### PR TITLE
Feat/35 change moving way

### DIFF
--- a/src/components/PrefectureSelector.tsx
+++ b/src/components/PrefectureSelector.tsx
@@ -32,9 +32,12 @@ const PrefectureSelector = () => {
   return (
     <>
       <Stack alignItems="center" sx={{ height: '100%', pb: 1 }}>
+        <div style={{ marginTop: '10px', marginBottom: '26px' }}>
+          <Typography variant="h3">Travel Planner</Typography>
+        </div>
         <Stack spacing={4}>
           <Stack direction="row" spacing={1} alignItems="center">
-            <Typography>Start / Goal: {selected.home?.name}</Typography>
+            <Typography>Home: {selected.home?.name}</Typography>
             <Button variant="outlined" onClick={() => setMode('home')}>
               Select
             </Button>
@@ -46,7 +49,7 @@ const PrefectureSelector = () => {
             </Button>
           </Stack>
           <Button
-            disabled={selected.home === null || selected.destination === null}
+            disabled={selected.destination === null}
             variant="contained"
             onClick={handleNext}>
             Plan Your Trip

--- a/src/components/RoutePlanner.tsx
+++ b/src/components/RoutePlanner.tsx
@@ -2,9 +2,6 @@ import * as React from 'react'
 import Box from '@mui/material/Box'
 import Button from '@mui/material/Button'
 import Stack from '@mui/material/Stack'
-import Stepper from '@mui/material/Stepper'
-import Step from '@mui/material/Step'
-import StepLabel from '@mui/material/StepLabel'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faAngleLeft } from '@fortawesome/free-solid-svg-icons'
 import Div100vh from 'react-div-100vh'
@@ -52,25 +49,6 @@ const RoutePlanner = () => {
           flex: 1,
           position: 'relative',
         }}>
-        <Stack direction="row">
-          <Button
-            color="inherit"
-            disabled={activeStep === 0}
-            onClick={handleBack}
-            sx={{ mr: 1 }}>
-            <Box pr={1}>
-              <FontAwesomeIcon icon={faAngleLeft} />
-            </Box>
-            Back
-          </Button>
-          <Stepper activeStep={activeStep} sx={{ flexGrow: 1 }}>
-            {steps.map((step) => (
-              <Step key={step.label}>
-                <StepLabel>{step.label}</StepLabel>
-              </Step>
-            ))}
-          </Stepper>
-        </Stack>
         <Box
           sx={{
             height: '100%',
@@ -89,12 +67,22 @@ const RoutePlanner = () => {
             </StepperHandlerContext.Provider>
           </Box>
         </Box>
-        <Box sx={{ display: 'flex', flexDirection: 'row' }}>
-          <Box sx={{ flex: '1 1 auto' }} />
-          {activeStep === steps.length - 1 && (
+        {activeStep === steps.length - 1 && (
+          <Stack direction="row">
+            <Button
+              color="inherit"
+              disabled={activeStep === 0}
+              onClick={handleBack}
+              sx={{ mr: 1 }}>
+              <Box pr={1}>
+                <FontAwesomeIcon icon={faAngleLeft} />
+              </Box>
+              Back
+            </Button>
+            <Box sx={{ flex: '1 1 auto' }} />
             <Button onClick={handleReset}>Reset</Button>
-          )}
-        </Box>
+          </Stack>
+        )}
       </Box>
     </Div100vh>
   )

--- a/src/components/RouteViewer.tsx
+++ b/src/components/RouteViewer.tsx
@@ -32,10 +32,16 @@ const RouteViewer = () => {
           (e): e is SpotEvent => e.extendedProps.type === 'spot'
         )
 
-        const result = await directionService.search(
-          selected.home.place_id,
-          waypoints.map((spot) => spot.extendedProps.placeId)
-        )
+        const result = await directionService.search({
+          origin: { placeId: selected.home.place_id },
+          destination: { placeId: selected.home.place_id },
+          waypoints: waypoints.map((spot) => ({
+            location: {
+              placeId: spot.extendedProps.placeId,
+            },
+          })),
+          travelMode: google.maps.TravelMode.DRIVING,
+        })
 
         // Event をクリアしてから、最適化された順番で再登録する
         eventsApi.clear()

--- a/src/components/RouteViewer.tsx
+++ b/src/components/RouteViewer.tsx
@@ -18,42 +18,44 @@ const RouteViewer = () => {
   const confirm = useConfirm({ allowClose: false })
 
   const handleOptimize = async () => {
-    if (selected.home) {
+    try {
       try {
-        try {
-          await confirm(
-            'Optimize your plan.\nWARNING: Current plan will be overwritten'
-          )
-        } catch {
-          // when cancel
-          return
-        }
-        const waypoints = events.filter(
-          (e): e is SpotEvent => e.extendedProps.type === 'spot'
+        await confirm(
+          'Optimize your plan.\nWARNING: Current plan will be overwritten'
         )
-
-        const result = await directionService.search({
-          origin: { placeId: selected.home.place_id },
-          destination: { placeId: selected.home.place_id },
-          waypoints: waypoints.map((spot) => ({
-            location: {
-              placeId: spot.extendedProps.placeId,
-            },
-          })),
-          travelMode: google.maps.TravelMode.DRIVING,
-        })
-
-        // Event をクリアしてから、最適化された順番で再登録する
-        eventsApi.clear()
-        for (const i of result.routes[0].waypoint_order) {
-          await eventsApi.add({
-            placeId: waypoints[i].extendedProps.placeId,
-            imageUrl: waypoints[i].extendedProps.imageUrl,
-          })
-        }
-      } catch (e) {
-        alert(e)
+      } catch {
+        // when cancel
+        return
       }
+      const waypoints = events.filter(
+        (e): e is SpotEvent => e.extendedProps.type === 'spot'
+      )
+
+      const result = await directionService.search({
+        origin: {
+          placeId: selected.home?.place_id || selected.destination?.place_id,
+        },
+        destination: {
+          placeId: selected.home?.place_id || selected.destination?.place_id,
+        },
+        waypoints: waypoints.map((spot) => ({
+          location: {
+            placeId: spot.extendedProps.placeId,
+          },
+        })),
+        travelMode: google.maps.TravelMode.DRIVING,
+      })
+
+      // Event をクリアしてから、最適化された順番で再登録する
+      eventsApi.clear()
+      for (const i of result.routes[0].waypoint_order) {
+        await eventsApi.add({
+          placeId: waypoints[i].extendedProps.placeId,
+          imageUrl: waypoints[i].extendedProps.imageUrl,
+        })
+      }
+    } catch (e) {
+      alert(e)
     }
   }
 
@@ -69,10 +71,7 @@ const RouteViewer = () => {
         <Typography variant="h4" component="h2">
           Your travel plan
         </Typography>
-        <Button
-          disabled={events.length < 2}
-          variant="contained"
-          onClick={handleOptimize}>
+        <Button variant="contained" onClick={handleOptimize}>
           Optimize
         </Button>
       </Stack>

--- a/src/components/organisms/EventToolbar.tsx
+++ b/src/components/organisms/EventToolbar.tsx
@@ -96,7 +96,7 @@ const EventToolbar: React.FC<Props> = ({ event }) => {
     spotsApi.update({
       ...moveToSelected,
       extendedProps: {
-        type: 'move',
+        ...moveToSelected.extendedProps,
         from: event.extendedProps.placeId,
         to: beforeSpot.id,
       },

--- a/src/components/organisms/MoveEventCard.tsx
+++ b/src/components/organisms/MoveEventCard.tsx
@@ -4,13 +4,12 @@ import ClickAwayListener from '@mui/material/ClickAwayListener'
 import Stack from '@mui/material/Stack'
 import Typography from '@mui/material/Typography'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { faCarSide } from '@fortawesome/free-solid-svg-icons'
 import { EventApi } from '@fullcalendar/react'
 import dayjs from 'dayjs'
 
 import { MoveEvent } from 'contexts/SelectedPlacesProvider'
 import { useToggle } from 'react-use'
-import MoveEventToolbar from './MoveEventToolbar'
+import MoveEventToolbar, { MoveTypes } from './MoveEventToolbar'
 
 const calcDiff = (start: Date, end: Date) => {
   const min = dayjs(end).diff(dayjs(start), 'minute')
@@ -40,7 +39,7 @@ const MoveEventCard: React.FC<Props> = ({ event }) => {
           }}>
           <Typography variant={'h5'}>
             <Stack direction="row" spacing={1} alignItems="center">
-              <FontAwesomeIcon icon={faCarSide} />
+              <FontAwesomeIcon icon={MoveTypes[event.extendedProps.mode]} />
               <span>
                 {event.start && event.end && calcDiff(event.start, event.end)}
               </span>

--- a/src/components/organisms/MoveEventCard.tsx
+++ b/src/components/organisms/MoveEventCard.tsx
@@ -22,11 +22,7 @@ type Props = {
 const MoveEventCard: React.FC<Props> = ({ event }) => {
   const [open, toggle] = useToggle(false)
   return (
-    <ClickAwayListener
-      onClickAway={(e) => {
-        console.log(e)
-        toggle(false)
-      }}>
+    <ClickAwayListener onClickAway={(e) => toggle(false)}>
       <Box
         onClick={() => toggle(true)}
         sx={{

--- a/src/components/organisms/MoveEventCard.tsx
+++ b/src/components/organisms/MoveEventCard.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react'
 import Box from '@mui/material/Box'
+import ClickAwayListener from '@mui/material/ClickAwayListener'
 import Stack from '@mui/material/Stack'
 import Typography from '@mui/material/Typography'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
@@ -8,6 +9,8 @@ import { EventApi } from '@fullcalendar/react'
 import dayjs from 'dayjs'
 
 import { MoveEvent } from 'contexts/SelectedPlacesProvider'
+import { useToggle } from 'react-use'
+import MoveEventToolbar from './MoveEventToolbar'
 
 const calcDiff = (start: Date, end: Date) => {
   const min = dayjs(end).diff(dayjs(start), 'minute')
@@ -17,21 +20,48 @@ type Props = {
   event: EventApi & { extendedProps: MoveEvent['extendedProps'] }
 }
 const MoveEventCard: React.FC<Props> = ({ event }) => {
+  const [open, toggle] = useToggle(false)
   return (
-    <Box
-      display="flex"
-      alignItems="center"
-      justifyContent="center"
-      sx={{ height: '100%', color: 'black' }}>
-      <Typography variant={'h5'}>
-        <Stack direction="row" spacing={1} alignItems="center">
-          <FontAwesomeIcon icon={faCarSide} />
-          <span>
-            {event.start && event.end && calcDiff(event.start, event.end)}
-          </span>
-        </Stack>
-      </Typography>
-    </Box>
+    <ClickAwayListener
+      onClickAway={(e) => {
+        console.log(e)
+        toggle(false)
+      }}>
+      <Box
+        onClick={() => toggle(true)}
+        sx={{
+          width: '100%',
+          height: '100%',
+          display: 'grid',
+          overflow: 'hidden',
+        }}>
+        <Box
+          sx={{
+            display: 'flex',
+            gridArea: '1/-1',
+            alignItems: 'center',
+            justifyContent: 'center',
+          }}>
+          <Typography variant={'h5'}>
+            <Stack direction="row" spacing={1} alignItems="center">
+              <FontAwesomeIcon icon={faCarSide} />
+              <span>
+                {event.start && event.end && calcDiff(event.start, event.end)}
+              </span>
+            </Stack>
+          </Typography>
+        </Box>
+        <Box
+          sx={{
+            width: '100%',
+            display: open ? 'flex' : 'none',
+            gridArea: '1/-1',
+            alignItems: 'end',
+          }}>
+          <MoveEventToolbar event={event} />
+        </Box>
+      </Box>
+    </ClickAwayListener>
   )
 }
 

--- a/src/components/organisms/MoveEventToolbar.tsx
+++ b/src/components/organisms/MoveEventToolbar.tsx
@@ -1,0 +1,45 @@
+import * as React from 'react'
+import IconButton from '@mui/material/IconButton'
+import Stack from '@mui/material/Stack'
+import {
+  FontAwesomeIcon,
+  FontAwesomeIconProps,
+} from '@fortawesome/react-fontawesome'
+import { faCar, faWalking } from '@fortawesome/free-solid-svg-icons'
+import { EventApi } from '@fullcalendar/react'
+
+import { MoveEvent } from 'contexts/SelectedPlacesProvider'
+
+const menus: Record<string, FontAwesomeIconProps['icon']> = {
+  car: faCar,
+  walk: faWalking,
+}
+type Props = {
+  event: EventApi & { extendedProps: MoveEvent['extendedProps'] }
+}
+const MoveEventToolbar: React.FC<Props> = ({ event }) => {
+  const [travelMode, setTravelMode] = React.useState<keyof typeof menus>('car')
+
+  const handleClickMode = (mode: keyof typeof menus) => () => {
+    setTravelMode(mode)
+    console.log(travelMode)
+  }
+
+  return (
+    <Stack
+      direction="row"
+      spacing={2}
+      sx={{ backgroundColor: 'lightgray', width: '100%', px: 1 }}>
+      {Object.entries(menus).map(([key, icon]) => (
+        <IconButton
+          color={key === travelMode ? 'primary' : 'inherit'}
+          key={key}
+          onClick={handleClickMode(key)}>
+          <FontAwesomeIcon icon={icon} />
+        </IconButton>
+      ))}
+    </Stack>
+  )
+}
+
+export default MoveEventToolbar

--- a/src/components/organisms/MoveEventToolbar.tsx
+++ b/src/components/organisms/MoveEventToolbar.tsx
@@ -7,22 +7,53 @@ import {
 } from '@fortawesome/react-fontawesome'
 import { faCar, faWalking } from '@fortawesome/free-solid-svg-icons'
 import { EventApi } from '@fullcalendar/react'
+import dayjs from 'dayjs'
 
 import { MoveEvent } from 'contexts/SelectedPlacesProvider'
+import { useDirections } from 'hooks/useDirections'
+import { useSelectSpots } from 'hooks/useSelectSpots'
 
 const menus: Record<string, FontAwesomeIconProps['icon']> = {
   car: faCar,
   walk: faWalking,
 }
+
 type Props = {
   event: EventApi & { extendedProps: MoveEvent['extendedProps'] }
 }
 const MoveEventToolbar: React.FC<Props> = ({ event }) => {
+  const directions = useDirections()
+  const [, eventsApi] = useSelectSpots()
   const [travelMode, setTravelMode] = React.useState<keyof typeof menus>('car')
 
-  const handleClickMode = (mode: keyof typeof menus) => () => {
+  const handleClickMode = (mode: keyof typeof menus) => async () => {
     setTravelMode(mode)
-    console.log(travelMode)
+
+    const moveEvent = eventsApi.get<MoveEvent>(event.id, 'move')
+    if (moveEvent === undefined) {
+      console.error('event is not managed')
+      return
+    }
+    const travelMode =
+      mode === 'car'
+        ? google.maps.TravelMode.DRIVING
+        : google.maps.TravelMode.WALKING
+
+    const result = await directions.search({
+      origin: { placeId: event.extendedProps.from },
+      destination: { placeId: event.extendedProps.to },
+      travelMode,
+    })
+
+    if (result.routes[0].legs.length > 0) {
+      const durationSec = result.routes[0].legs[0].duration?.value || 0
+      eventsApi.update({
+        ...moveEvent,
+        end: dayjs(event.start).add(durationSec, 'second').toDate(),
+      })
+
+      eventsApi.applyChange(moveEvent, durationSec / 60)
+    }
   }
 
   return (
@@ -32,8 +63,8 @@ const MoveEventToolbar: React.FC<Props> = ({ event }) => {
       sx={{ backgroundColor: 'lightgray', width: '100%', px: 1 }}>
       {Object.entries(menus).map(([key, icon]) => (
         <IconButton
-          color={key === travelMode ? 'primary' : 'inherit'}
           key={key}
+          color={key === travelMode ? 'primary' : 'inherit'}
           onClick={handleClickMode(key)}>
           <FontAwesomeIcon icon={icon} />
         </IconButton>

--- a/src/components/organisms/MoveEventToolbar.tsx
+++ b/src/components/organisms/MoveEventToolbar.tsx
@@ -13,7 +13,10 @@ import { MoveEvent } from 'contexts/SelectedPlacesProvider'
 import { useDirections } from 'hooks/useDirections'
 import { useSelectSpots } from 'hooks/useSelectSpots'
 
-const menus: Record<string, FontAwesomeIconProps['icon']> = {
+const menus: Record<
+  MoveEvent['extendedProps']['mode'],
+  FontAwesomeIconProps['icon']
+> = {
   car: faCar,
   walk: faWalking,
 }
@@ -24,11 +27,8 @@ type Props = {
 const MoveEventToolbar: React.FC<Props> = ({ event }) => {
   const directions = useDirections()
   const [, eventsApi] = useSelectSpots()
-  const [travelMode, setTravelMode] = React.useState<keyof typeof menus>('car')
 
   const handleClickMode = (mode: keyof typeof menus) => async () => {
-    setTravelMode(mode)
-
     const moveEvent = eventsApi.get<MoveEvent>(event.id, 'move')
     if (moveEvent === undefined) {
       console.error('event is not managed')
@@ -47,12 +47,15 @@ const MoveEventToolbar: React.FC<Props> = ({ event }) => {
 
     if (result.routes[0].legs.length > 0) {
       const durationSec = result.routes[0].legs[0].duration?.value || 0
+      const newEnd = dayjs(event.start).add(durationSec, 'second')
+      const durationDiff = dayjs(newEnd).diff(moveEvent.end, 'minute')
+      moveEvent.extendedProps.mode = mode
       eventsApi.update({
         ...moveEvent,
-        end: dayjs(event.start).add(durationSec, 'second').toDate(),
+        end: newEnd.toDate(),
       })
 
-      eventsApi.applyChange(moveEvent, durationSec / 60)
+      eventsApi.applyChange(moveEvent, durationDiff)
     }
   }
 
@@ -64,8 +67,8 @@ const MoveEventToolbar: React.FC<Props> = ({ event }) => {
       {Object.entries(menus).map(([key, icon]) => (
         <IconButton
           key={key}
-          color={key === travelMode ? 'primary' : 'inherit'}
-          onClick={handleClickMode(key)}>
+          color={key === event.extendedProps.mode ? 'primary' : 'inherit'}
+          onClick={handleClickMode(key as keyof typeof menus)}>
           <FontAwesomeIcon icon={icon} />
         </IconButton>
       ))}

--- a/src/components/organisms/PlanEditor.tsx
+++ b/src/components/organisms/PlanEditor.tsx
@@ -316,7 +316,8 @@ const PlanEditor = () => {
             allDaySlot={false}
             editable={true}
             selectable={true}
-            selectMirror={true}
+            selectMinDistance={10} // will not fire select not to drag mouse
+            // selectMirror={true}
             droppable={true}
             dayMaxEvents={true}
             weekends={true}

--- a/src/contexts/SelectedPlacesProvider.tsx
+++ b/src/contexts/SelectedPlacesProvider.tsx
@@ -14,7 +14,7 @@ export type Move = {
   type: 'move'
   from: string
   to: string
-  mode: 'car' | 'walk'
+  mode: 'bicycle' | 'car' | 'walk'
 }
 type CustomEventInput = Omit<EventInput, 'extendedProps'>
 export type SpotEvent = CustomEventInput & {

--- a/src/contexts/SelectedPlacesProvider.tsx
+++ b/src/contexts/SelectedPlacesProvider.tsx
@@ -14,6 +14,7 @@ export type Move = {
   type: 'move'
   from: string
   to: string
+  mode: 'car' | 'walk'
 }
 type CustomEventInput = Omit<EventInput, 'extendedProps'>
 export type SpotEvent = CustomEventInput & {

--- a/src/hooks/useDirections.ts
+++ b/src/hooks/useDirections.ts
@@ -10,24 +10,16 @@ export const useDirections = () => {
    * @param placeIds PlaceID のリスト
    */
   const search = React.useCallback(
-    async (homeId: string, waypoints?: Array<string>) => {
+    async (props: google.maps.DirectionsRequest) => {
       if (direction === null) {
         throw Error('JS Google Map api is not loaded')
       }
 
-      const origin = { placeId: homeId }
-      const destination = { placeId: homeId }
-
       const result = await direction.route(
         {
-          origin,
-          destination,
-          waypoints: waypoints?.map((placeId) => ({
-            location: { placeId: placeId },
-          })),
+          ...props,
           optimizeWaypoints: true,
           region: 'JP',
-          travelMode: google.maps.TravelMode.DRIVING,
         },
         (result, status) => {
           if (status === google.maps.DirectionsStatus.OK) {

--- a/src/hooks/useSelectSpots.ts
+++ b/src/hooks/useSelectSpots.ts
@@ -18,6 +18,26 @@ function createEventId() {
   return String(eventGuid++)
 }
 
+const buildMoveEvent = (
+  start: MoveEvent['start'],
+  end: MoveEvent['end'],
+  props: Pick<MoveEvent['extendedProps'], 'from' | 'to'>
+): MoveEvent => {
+  return {
+    id: createEventId(),
+    title: 'Move',
+    color: 'white',
+    display: 'background',
+    start,
+    end,
+    extendedProps: {
+      type: 'move',
+      mode: 'car',
+      ...props,
+    },
+  }
+}
+
 const findLastSpot = (spots: ScheduleEvent[]): SpotEvent | null => {
   const spotEvents = spots.filter(
     (spot): spot is SpotEvent => spot.extendedProps.type === 'spot'
@@ -118,23 +138,23 @@ export const useSelectSpots = () => {
           start = moveStart.add(1, 'day').hour(9).minute(0).second(0)
           fromId = lastSpot.id
         } else {
-          const moveEvent: MoveEvent = {
-            id: createEventId(),
-            title: 'Car',
-            start: moveStart.toDate(),
-            end: moveEnd.toDate(),
-            color: 'white',
-            display: 'background',
-            extendedProps: {
-              type: 'move',
+          const moveEvent: MoveEvent = buildMoveEvent(
+            moveStart.toDate(),
+            moveEnd.toDate(),
+            {
               from: lastSpot.extendedProps.placeId,
               to: newSpot.placeId,
-            },
-          }
+            }
+          )
           actions.push(moveEvent)
 
-          lastSpot.extendedProps.to = moveEvent.id
-          update(lastSpot)
+          update({
+            ...lastSpot,
+            extendedProps: {
+              ...lastSpot.extendedProps,
+              to: moveEvent.id,
+            },
+          })
           start = moveEnd
           fromId = moveEvent.id
         }
@@ -252,19 +272,14 @@ export const useSelectSpots = () => {
 
           beforeMoveId = overlappedMoveEvent.id
         } else {
-          const beforeMoveEvent: MoveEvent = {
-            id: createEventId(),
-            title: 'Car',
-            start: prevSpot.end,
-            end: beforeMoveEnd.toDate(),
-            color: 'white',
-            display: 'background',
-            extendedProps: {
-              type: 'move',
+          const beforeMoveEvent = buildMoveEvent(
+            prevSpot.end,
+            beforeMoveEnd.toDate(),
+            {
               from: beforeOrg[0].placeId,
               to: beforeDest[0].placeId,
-            },
-          }
+            }
+          )
           actions.push(beforeMoveEvent)
 
           beforeMoveId = beforeMoveEvent.id
@@ -303,19 +318,14 @@ export const useSelectSpots = () => {
         )
         const moveEndChange = moveEnd.diff(nextSpot.start, 'minute')
 
-        const moveEvent: MoveEvent = {
-          id: createEventId(),
-          title: 'Car',
-          start: moveStart.toDate(),
-          end: moveEnd.toDate(),
-          color: 'white',
-          display: 'background',
-          extendedProps: {
-            type: 'move',
+        const moveEvent: MoveEvent = buildMoveEvent(
+          moveStart.toDate(),
+          moveEnd.toDate(),
+          {
             from: org[0].placeId,
             to: dest[0].placeId,
-          },
-        }
+          }
+        )
 
         actions.push(moveEvent)
         afterMoveId = moveEvent.id


### PR DESCRIPTION
close #35 #65 

- Move イベントをクリックして移動方法を変更できるようにした
- デフォルトは車移動、徒歩と自転車を選択可能
- 電車移動は　Google Maps API が対応していないので未実装
- ヘッダーを消した