### PR TITLE
Feat/15 enhance icon

### DIFF
--- a/src/components/organisms/CategorySelector.tsx
+++ b/src/components/organisms/CategorySelector.tsx
@@ -15,7 +15,7 @@ type Props = {
   onChange?: (value: number) => void
 }
 const CategorySelector: React.FC<Props> = ({ onChange: changedCallback }) => {
-  const [selectedId, setSelectedId] = React.useState(0)
+  const [selectedId, setSelectedId] = React.useState<number | null>(null)
   const [label, setLabel] = React.useState('')
   const { data, loading, error } = useGetCategoriesQuery()
   const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null)
@@ -27,8 +27,12 @@ const CategorySelector: React.FC<Props> = ({ onChange: changedCallback }) => {
   }
 
   React.useEffect(() => {
-    changedCallback?.(selectedId)
-  }, [changedCallback, selectedId])
+    if (selectedId) {
+      changedCallback?.(selectedId)
+    }
+    // not update callback when mapBounds is changed
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [selectedId])
 
   const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     const id = Number.parseInt(event.target.value)

--- a/src/components/organisms/GoogleMap.tsx
+++ b/src/components/organisms/GoogleMap.tsx
@@ -51,17 +51,17 @@ const RenderMap: React.FC<Props> = React.memo(function Map({
   // wrapping to a function is useful in case you want to access `window.google`
   // to eg. setup options or create latLng object, it won't be available otherwise
   // feel free to render directly if you don't need that
-  const onLoad = React.useCallback(
-    (mapInstance: google.maps.Map) => {
-      // do something with map Instance
-      setDirectionService(new window.google.maps.DirectionsService())
-      setDistanceMatrix(new window.google.maps.DistanceMatrixService())
-      setPlaces(new window.google.maps.places.PlacesService(mapInstance))
+  const onLoad = (mapInstance: google.maps.Map) => {
+    // do something with map Instance
+    setDirectionService(new window.google.maps.DirectionsService())
+    setDistanceMatrix(new window.google.maps.DistanceMatrixService())
+    setPlaces(new window.google.maps.places.PlacesService(mapInstance))
 
-      setGoogleMap(mapInstance)
-    },
-    [setDirectionService, setDistanceMatrix, setPlaces]
-  )
+    const bounds = mapInstance.getBounds()
+    setMapBounds({ ne: bounds?.getNorthEast(), sw: bounds?.getSouthWest() })
+
+    setGoogleMap(mapInstance)
+  }
 
   return (
     <GoogleMapLib

--- a/src/components/organisms/PlaceMarker.tsx
+++ b/src/components/organisms/PlaceMarker.tsx
@@ -3,15 +3,41 @@ import { Marker } from '@react-google-maps/api'
 
 type Props = {
   placeId: string
+  selected: boolean
   lat: number
   lng: number
   onClick: (placeId: string) => void
 }
-const PlaceMarker: React.FC<Props> = ({ placeId, lat, lng, onClick }) => {
+const PlaceMarker: React.FC<Props> = ({
+  placeId,
+  selected,
+  lat,
+  lng,
+  onClick,
+}) => {
   const handleClick = () => {
     onClick(placeId)
   }
-  return <Marker position={{ lat, lng }} onClick={handleClick}></Marker>
+  return (
+    <Marker
+      icon={
+        selected
+          ? undefined
+          : {
+              // default anchor(0,0) is position
+              // Set (width * scale / 2, height * scale / 2) to move center of icon to position.
+              anchor: new google.maps.Point(10, 10),
+              path: 'M20 10C20 15.5228 15.5228 20 10 20C4.47715 20 0 15.5228 0 10C0 4.47715 4.47715 0 10 0C15.5228 0 20 4.47715 20 10Z',
+              fillColor: '#D95140',
+              fillOpacity: 1,
+              scale: 1,
+              strokeColor: '#FFF',
+              strokeWeight: 1,
+            }
+      }
+      position={{ lat, lng }}
+      onClick={handleClick}></Marker>
+  )
 }
 
 export default PlaceMarker

--- a/src/components/organisms/SpotsMap.tsx
+++ b/src/components/organisms/SpotsMap.tsx
@@ -23,6 +23,7 @@ const SpotsMap = () => {
 
   const handleSelectCategory = React.useCallback(
     async (id: number) => {
+      console.log(mapBounds)
       if (mapBounds.ne && mapBounds.sw) {
         const results = await getSpots({
           variables: {
@@ -37,6 +38,7 @@ const SpotsMap = () => {
         if (results.error) {
           console.error(`Fail to fetch types by category id ${id}`)
         }
+        console.log(results.data)
         setSpots(results.data?.spots || [])
       }
     },
@@ -64,6 +66,7 @@ const SpotsMap = () => {
             <PlaceMarker
               key={item.place_id}
               placeId={item.place_id}
+              selected={item.place_id === focusedSpot}
               lat={item.lat}
               lng={item.lng}
               onClick={handleMarkerClicked}

--- a/src/components/organisms/SpotsMap.tsx
+++ b/src/components/organisms/SpotsMap.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react'
 import Box from '@mui/material/Box'
+import ClickAwayListener from '@mui/material/ClickAwayListener'
 import Stack from '@mui/material/Stack'
 
 import CategorySelector from './CategorySelector'
@@ -78,20 +79,24 @@ const SpotsMap = () => {
           <CategorySelector onChange={handleSelectCategory} />
         </Stack>
       </Box>
-      <Box
-        sx={{
-          zIndex: 10,
-          position: 'absolute',
-          bottom: 0,
-          left: '50%',
-          transform: 'translateX(-50%)',
-          pb: 2,
-          width: '90%',
-          maxWidth: '400px',
-          maxHeight: '150px',
-        }}>
-        {focusedSpot && <SpotsList spots={[focusedSpot]} />}
-      </Box>
+      {focusedSpot && (
+        <ClickAwayListener onClickAway={() => setFocusedSpot('')}>
+          <Box
+            sx={{
+              zIndex: 10,
+              position: 'absolute',
+              bottom: 0,
+              left: '50%',
+              transform: 'translateX(-50%)',
+              pb: 2,
+              width: '90%',
+              maxWidth: '400px',
+              maxHeight: '150px',
+            }}>
+            <SpotsList spots={[focusedSpot]} />
+          </Box>
+        </ClickAwayListener>
+      )}
     </Box>
   )
 }

--- a/src/components/organisms/SpotsMap.tsx
+++ b/src/components/organisms/SpotsMap.tsx
@@ -42,9 +42,7 @@ const SpotsMap = () => {
         setSpots(results.data?.spots || [])
       }
     },
-    // not update callback when mapBounds is changed
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [getSpots]
+    [getSpots, mapBounds]
   )
 
   const handleMarkerClicked = (placeId: string) => {


### PR DESCRIPTION
close #15 

- 選択中のスポットがわかりやすくなるように、未選択状態と選択状態でアイコンを変更する
- 未選択のときはシンプルな丸を表示
- 選択中はデフォルトのピンアイコンを表示

## その他

- 選択中カードの外をクリックした場合に、選択状態を解除するように変更
- スポットの検索範囲を表示範囲内に限定した
  - デフォルト以外のアイコンを表示していると、マップが重たくなるため