### PR TITLE
Fix/50 created midnight

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,7 @@ import { DirectionServiceProvider } from 'contexts/DirectionServiceProvider'
 import { DistanceMatrixProvider } from 'contexts/DistanceMatrixProvider'
 import { PlacesServiceProvider } from 'contexts/PlacesServiceProvider'
 import { ConfirmationProvider } from 'contexts/ConfirmationProvider'
+import { MapPropsProvider } from 'contexts/MapPropsProvider'
 
 function App() {
   return (
@@ -15,13 +16,15 @@ function App() {
       <ConfirmationProvider>
         <DirectionServiceProvider>
           <DistanceMatrixProvider>
-            <PlacesServiceProvider>
-              <SelectedPrefectureProvider>
-                <SelectedPlacesProvider>
-                  <RoutePlanner />
-                </SelectedPlacesProvider>
-              </SelectedPrefectureProvider>
-            </PlacesServiceProvider>
+            <MapPropsProvider>
+              <PlacesServiceProvider>
+                <SelectedPrefectureProvider>
+                  <SelectedPlacesProvider>
+                    <RoutePlanner />
+                  </SelectedPlacesProvider>
+                </SelectedPrefectureProvider>
+              </PlacesServiceProvider>
+            </MapPropsProvider>
           </DistanceMatrixProvider>
         </DirectionServiceProvider>
       </ConfirmationProvider>

--- a/src/components/PrefectureSelector.tsx
+++ b/src/components/PrefectureSelector.tsx
@@ -10,11 +10,13 @@ import {
   SelectedPrefectureContext,
   SetSelectedPrefectureContext,
 } from 'contexts/SelectedPrefectureProvider'
+import { useMapProps } from 'hooks/useMapProps'
 
 const PrefectureSelector = () => {
   const handleNext = React.useContext(StepperHandlerContext)
   const selected = React.useContext(SelectedPrefectureContext)
   const setSelected = React.useContext(SetSelectedPrefectureContext)
+  const [, setMapProps] = useMapProps()
 
   const [mode, setMode] = React.useState<
     keyof NonNullable<typeof selected> | null
@@ -25,6 +27,14 @@ const PrefectureSelector = () => {
   const handleSelectPrefecture = (prefecture: Prefecture) => {
     if (mode) {
       setSelected((prev) => ({ ...prev, [mode]: prefecture }))
+
+      if (mode === 'destination') {
+        setMapProps((prev) => ({
+          ...prev,
+          center: { lat: prefecture.lat, lng: prefecture.lng },
+          zoom: prefecture.zoom,
+        }))
+      }
     }
     setMode(null)
   }

--- a/src/components/organisms/SpotsMap.tsx
+++ b/src/components/organisms/SpotsMap.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react'
 import Box from '@mui/material/Box'
-import ClickAwayListener from '@mui/material/ClickAwayListener'
 import Stack from '@mui/material/Stack'
 
 import CategorySelector from './CategorySelector'
@@ -13,12 +12,18 @@ import {
   useGetSpotsByCategoryLazyQuery,
 } from 'generated/graphql'
 import SpotsList from './SpotsList'
+import { useClickAway } from 'react-use'
 
 const SpotsMap = () => {
   const [spots, setSpots] = React.useState<GetSpotsByCategoryQuery['spots']>([])
   const [getSpots] = useGetSpotsByCategoryLazyQuery()
   const { destination } = React.useContext(SelectedPrefectureContext)
   const [mapBounds, setMapBounds] = React.useState<Bounds>({})
+
+  const spotCardRef = React.useRef<HTMLDivElement>(null)
+  useClickAway(spotCardRef, (e) => {
+    setFocusedSpot('')
+  })
 
   const [focusedSpot, setFocusedSpot] = React.useState('')
 
@@ -80,22 +85,21 @@ const SpotsMap = () => {
         </Stack>
       </Box>
       {focusedSpot && (
-        <ClickAwayListener onClickAway={() => setFocusedSpot('')}>
-          <Box
-            sx={{
-              zIndex: 10,
-              position: 'absolute',
-              bottom: 0,
-              left: '50%',
-              transform: 'translateX(-50%)',
-              pb: 2,
-              width: '90%',
-              maxWidth: '400px',
-              maxHeight: '150px',
-            }}>
-            <SpotsList spots={[focusedSpot]} />
-          </Box>
-        </ClickAwayListener>
+        <Box
+          ref={spotCardRef}
+          sx={{
+            zIndex: 10,
+            position: 'absolute',
+            bottom: 0,
+            left: '50%',
+            transform: 'translateX(-50%)',
+            pb: 2,
+            width: '90%',
+            maxWidth: '400px',
+            maxHeight: '150px',
+          }}>
+          <SpotsList spots={[focusedSpot]} />
+        </Box>
       )}
     </Box>
   )

--- a/src/contexts/MapPropsProvider.tsx
+++ b/src/contexts/MapPropsProvider.tsx
@@ -1,0 +1,35 @@
+import * as React from 'react'
+
+const DEFAULT_CENTER = { lat: 36.5941035450526, lng: 138.70038569359122 }
+
+export type Bounds = {
+  sw?: google.maps.LatLng | null
+  ne?: google.maps.LatLng | null
+}
+type MapProps = {
+  center: google.maps.LatLngLiteral | google.maps.LatLng
+  zoom: number
+  bounds: Bounds | null
+}
+export const MapPropsContext = React.createContext<MapProps | null>(null)
+export const SetMapPropsContext = React.createContext<
+  React.Dispatch<React.SetStateAction<MapProps>>
+>(() => {
+  throw new Error('MapPropsProvider is not wrapped')
+})
+
+export const MapPropsProvider: React.FC = ({ children }) => {
+  const [mapProps, setMapProps] = React.useState<MapProps>({
+    center: DEFAULT_CENTER,
+    zoom: 4,
+    bounds: null,
+  })
+
+  return (
+    <MapPropsContext.Provider value={mapProps}>
+      <SetMapPropsContext.Provider value={setMapProps}>
+        {children}
+      </SetMapPropsContext.Provider>
+    </MapPropsContext.Provider>
+  )
+}

--- a/src/hooks/useMapProps.ts
+++ b/src/hooks/useMapProps.ts
@@ -1,0 +1,13 @@
+import { MapPropsContext, SetMapPropsContext } from 'contexts/MapPropsProvider'
+import * as React from 'react'
+
+export const useMapProps = () => {
+  const mapProps = React.useContext(MapPropsContext)
+  const setMapProps = React.useContext(SetMapPropsContext)
+
+  if (mapProps === null) {
+    throw new Error('MapPropsProvider is not wrapped')
+  }
+
+  return [mapProps, setMapProps] as const
+}

--- a/src/hooks/useSelectSpots.ts
+++ b/src/hooks/useSelectSpots.ts
@@ -133,7 +133,7 @@ export const useSelectSpots = () => {
           result.rows[0].elements[0].duration.value,
           's'
         )
-        if (moveEnd.hour() >= 19) {
+        if (moveEnd.isAfter(moveEnd.set('hour', 19).set('minute', 0))) {
           // 時刻がlimit を超えた場合は Move イベントはスキップして次の日へ移行する
           start = moveStart.add(1, 'day').hour(9).minute(0).second(0)
           fromId = lastSpot.id


### PR DESCRIPTION
close #50 

- 移動イベントが次の日までまたがる場合に、イベントが次の日の朝からにならない問題の修正
  - イベントのリミットを時刻だけで判定していたので、深夜になるとリミットを超えていない判定になっていた
- その他バグ修正
  - スケジューラーから Back すると、マップの状態がリセットされる
    - マップの状態をコンテクストで持つことで対応