### PR TITLE
Prevent unintentional move

### DIFF
--- a/src/components/organisms/PlanEditor.tsx
+++ b/src/components/organisms/PlanEditor.tsx
@@ -299,7 +299,7 @@ const PlanEditor = () => {
             }}
             scrollTime="08:00:00" // Default start time when render the timegrid.
             dayCellClassNames="my-day-cell"
-            snapDuration="00:15:00"
+            snapDuration="00:30:00" // Cause unintentional movement if this is small
             slotDuration="01:00:00"
             slotLabelInterval="01:00:00"
             slotLabelFormat={{


### PR DESCRIPTION
Close #66 

- スポットイベントを動かす際に、最初に意図しない動作が発生してしまうのを防止した
- 意図しない動作が起こるのは、カードの移動区間の境界をタップしたとき
  - 移動区間を広げることで、境界値付近をタップする確率を減らした
  - あくまで確率を減らしただけなので、対象の問題は依然として起こりうる
  - 完全な解決方法はまだ思いつかない