### PR TITLE
Feat/73 home route

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,6 +9,7 @@ import { DistanceMatrixProvider } from 'contexts/DistanceMatrixProvider'
 import { PlacesServiceProvider } from 'contexts/PlacesServiceProvider'
 import { ConfirmationProvider } from 'contexts/ConfirmationProvider'
 import { MapPropsProvider } from 'contexts/MapPropsProvider'
+import { SelectedSpotsProvider } from 'contexts/SelectedSpotsProvider'
 
 function App() {
   return (
@@ -19,9 +20,11 @@ function App() {
             <MapPropsProvider>
               <PlacesServiceProvider>
                 <SelectedPrefectureProvider>
-                  <SelectedPlacesProvider>
-                    <RoutePlanner />
-                  </SelectedPlacesProvider>
+                  <SelectedSpotsProvider>
+                    <SelectedPlacesProvider>
+                      <RoutePlanner />
+                    </SelectedPlacesProvider>
+                  </SelectedSpotsProvider>
                 </SelectedPrefectureProvider>
               </PlacesServiceProvider>
             </MapPropsProvider>

--- a/src/components/FeaturedPlaces.tsx
+++ b/src/components/FeaturedPlaces.tsx
@@ -4,10 +4,6 @@ import Box from '@mui/material/Box'
 import Button from '@mui/material/Button'
 import Stack from '@mui/material/Stack'
 
-import {
-  SelectedPlacesContext,
-  SpotEvent,
-} from 'contexts/SelectedPlacesProvider'
 import { StepperHandlerContext } from './RoutePlanner'
 import SpotsCandidates from './organisms/SpotsCandidates'
 import SpotsMap from './organisms/SpotsMap'
@@ -16,7 +12,6 @@ import { useSelectedSpots } from 'hooks/useSelectedSpots'
 
 const FeaturedPlaces = () => {
   const [open, setOpen] = React.useState(false)
-  const places = React.useContext(SelectedPlacesContext)
   const handleNext = React.useContext(StepperHandlerContext)
   const { events, actions } = useSelectSpots()
   const [spots, spotsActions] = useSelectedSpots()
@@ -27,7 +22,6 @@ const FeaturedPlaces = () => {
   }, [])
 
   const handleClickNext = async () => {
-    console.log(spots)
     await actions.generateRoute(spots)
     handleNext()
   }
@@ -55,11 +49,7 @@ const FeaturedPlaces = () => {
           direction="row"
           justifyContent="space-between"
           alignItems="baseline">
-          <Badge
-            badgeContent={
-              places.filter((item) => item.extendedProps.type === 'spot').length
-            }
-            color="primary">
+          <Badge badgeContent={spots.length} color="primary">
             <Button variant="text" onClick={handleOpen}>
               Spots List
             </Button>
@@ -79,11 +69,7 @@ const FeaturedPlaces = () => {
       </Box>
       <SpotsCandidates
         open={open}
-        placeIds={places
-          .filter(
-            (place): place is SpotEvent => place.extendedProps.type === 'spot'
-          )
-          .map((spot) => spot.extendedProps.placeId)}
+        placeIds={spots.map((spot) => spot.placeId)}
         onOpen={handleOpen}
         onClose={handleClose}
       />

--- a/src/components/FeaturedPlaces.tsx
+++ b/src/components/FeaturedPlaces.tsx
@@ -11,11 +11,26 @@ import {
 import { StepperHandlerContext } from './RoutePlanner'
 import SpotsCandidates from './organisms/SpotsCandidates'
 import SpotsMap from './organisms/SpotsMap'
+import { useSelectSpots } from 'hooks/useSelectSpots'
+import { useSelectedSpots } from 'hooks/useSelectedSpots'
 
 const FeaturedPlaces = () => {
   const [open, setOpen] = React.useState(false)
   const places = React.useContext(SelectedPlacesContext)
   const handleNext = React.useContext(StepperHandlerContext)
+  const { events, actions } = useSelectSpots()
+  const [spots, spotsActions] = useSelectedSpots()
+
+  React.useEffect(() => {
+    spotsActions.init(events)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  const handleClickNext = async () => {
+    console.log(spots)
+    await actions.generateRoute(spots)
+    handleNext()
+  }
 
   const handleOpen = () => {
     setOpen(true)
@@ -57,10 +72,7 @@ const FeaturedPlaces = () => {
               borderRadius: 3,
             }}
           />
-          <Button
-            variant="contained"
-            disabled={places.length === 0}
-            onClick={handleNext}>
+          <Button variant="contained" onClick={handleClickNext}>
             Get Route
           </Button>
         </Stack>

--- a/src/components/FeaturedPlaces.tsx
+++ b/src/components/FeaturedPlaces.tsx
@@ -67,7 +67,7 @@ const FeaturedPlaces = () => {
       </Box>
       <SpotsCandidates
         open={open}
-        places={places
+        placeIds={places
           .filter(
             (place): place is SpotEvent => place.extendedProps.type === 'spot'
           )

--- a/src/components/PrefectureSelector.tsx
+++ b/src/components/PrefectureSelector.tsx
@@ -11,12 +11,14 @@ import {
   SetSelectedPrefectureContext,
 } from 'contexts/SelectedPrefectureProvider'
 import { useMapProps } from 'hooks/useMapProps'
+import { useSelectSpots } from 'hooks/useSelectSpots'
 
 const PrefectureSelector = () => {
   const handleNext = React.useContext(StepperHandlerContext)
   const selected = React.useContext(SelectedPrefectureContext)
   const setSelected = React.useContext(SetSelectedPrefectureContext)
   const [, setMapProps] = useMapProps()
+  const { actions: eventsApi } = useSelectSpots()
 
   const [mode, setMode] = React.useState<
     keyof NonNullable<typeof selected> | null
@@ -37,6 +39,11 @@ const PrefectureSelector = () => {
       }
     }
     setMode(null)
+  }
+
+  const handleCreatePlan = () => {
+    eventsApi.init()
+    handleNext()
   }
 
   return (
@@ -61,7 +68,7 @@ const PrefectureSelector = () => {
           <Button
             disabled={!selected.destination}
             variant="contained"
-            onClick={handleNext}>
+            onClick={handleCreatePlan}>
             Plan Your Trip
           </Button>
         </Stack>

--- a/src/components/RouteViewer.tsx
+++ b/src/components/RouteViewer.tsx
@@ -9,19 +9,12 @@ import Typography from '@mui/material/Typography'
 import PlanEditor from './organisms/PlanEditor'
 import { useDirections } from 'hooks/useDirections'
 import { useSelectSpots } from 'hooks/useSelectSpots'
-import { SpotEvent } from 'contexts/SelectedPlacesProvider'
-import { SelectedPrefectureContext } from 'contexts/SelectedPrefectureProvider'
 import { useConfirm } from 'hooks/useConfirm'
 
 const RouteViewer = () => {
-  const { actions: directionService, loading } = useDirections()
-  const selected = React.useContext(SelectedPrefectureContext)
-  const { events, actions: eventsApi } = useSelectSpots()
+  const { loading } = useDirections()
+  const { actions: eventsApi } = useSelectSpots()
   const confirm = useConfirm({ allowClose: false })
-
-  React.useEffect(() => {
-    console.log(loading)
-  }, [loading])
 
   const handleOptimize = async () => {
     try {
@@ -33,33 +26,11 @@ const RouteViewer = () => {
         // when cancel
         return
       }
-      const waypoints = events.filter(
-        (e): e is SpotEvent => e.extendedProps.type === 'spot'
-      )
-
-      const result = await directionService.search({
-        origin: {
-          placeId: selected.home?.place_id || selected.destination?.place_id,
-        },
-        destination: {
-          placeId: selected.home?.place_id || selected.destination?.place_id,
-        },
-        waypoints: waypoints.map((spot) => ({
-          location: {
-            placeId: spot.extendedProps.placeId,
-          },
-        })),
-        travelMode: google.maps.TravelMode.DRIVING,
-      })
-
-      // Event をクリアしてから、最適化された順番で再登録する
-      eventsApi.init()
-      for (const i of result.routes[0].waypoint_order) {
-        await eventsApi.add({
-          placeId: waypoints[i].extendedProps.placeId,
-          imageUrl: waypoints[i].extendedProps.imageUrl,
-        })
-      }
+      const waypoints = eventsApi.getDestinations().map((event) => ({
+        placeId: event.extendedProps.placeId,
+        imageUrl: event.extendedProps.imageUrl,
+      }))
+      eventsApi.generateRoute(waypoints)
     } catch (e) {
       alert(e)
     }

--- a/src/components/RouteViewer.tsx
+++ b/src/components/RouteViewer.tsx
@@ -53,7 +53,7 @@ const RouteViewer = () => {
       })
 
       // Event をクリアしてから、最適化された順番で再登録する
-      eventsApi.clear()
+      eventsApi.init()
       for (const i of result.routes[0].waypoint_order) {
         await eventsApi.add({
           placeId: waypoints[i].extendedProps.placeId,

--- a/src/components/organisms/EventToolbar.tsx
+++ b/src/components/organisms/EventToolbar.tsx
@@ -10,245 +10,47 @@ import {
 } from '@fortawesome/free-solid-svg-icons'
 import { EventApi } from '@fullcalendar/react'
 
-import { useDistanceMatrix } from 'hooks/useDistanceMatrix'
 import { useSelectSpots } from 'hooks/useSelectSpots'
-import {
-  MoveEvent,
-  ScheduleEvent,
-  SpotEvent,
-} from 'contexts/SelectedPlacesProvider'
-import dayjs from 'dayjs'
+import { ScheduleEvent, SpotEvent } from 'contexts/SelectedPlacesProvider'
 
 type Props = {
   event: EventApi & { extendedProps: SpotEvent['extendedProps'] }
 }
 const EventToolbar: React.FC<Props> = ({ event }) => {
-  const { events: spots, actions: spotsApi } = useSelectSpots()
-  const distanceMatrix = useDistanceMatrix()
+  const { actions: spotsApi } = useSelectSpots()
 
   const handleUp = async () => {
     console.log('up')
-
-    const moveFromSelected = spots.find(
-      (spot): spot is MoveEvent =>
-        spot.extendedProps.type === 'move' &&
-        spot.extendedProps.from === event.extendedProps.placeId
-    )
-    const moveToSelected = spots.find(
-      (spot): spot is MoveEvent =>
-        spot.extendedProps.type === 'move' &&
-        spot.extendedProps.to === event.extendedProps.placeId
-    )
-
-    const beforeSpot = spots.find(
-      (spot): spot is SpotEvent =>
-        spot.id === moveToSelected?.extendedProps.from
-    )
-
-    // 直前に移動イベントがない場合は移動不可
-    if (moveToSelected === undefined || beforeSpot === undefined) {
-      console.log('cannot move up event')
+    const selectedSpot = spotsApi.get<SpotEvent>(event.id, 'spot')
+    if (selectedSpot === undefined) {
+      console.error('cannot find selected spot')
       return
     }
 
-    // 直前のスポットへの移動イベントを取得
-    const moveToBeforeSpot = spots.find(
-      (spot): spot is MoveEvent =>
-        spot.extendedProps.type === 'move' &&
-        spot.extendedProps.to === beforeSpot.id
-    )
-
-    if (moveToBeforeSpot) {
-      // 直前のスポットへの移動イベントを選択中のイベントへの移動イベントに更新
-      const org = [{ placeId: moveToBeforeSpot.extendedProps.from }]
-      const dest = [{ placeId: event.extendedProps.placeId }]
-      const result = await distanceMatrix.search(org, dest)
-
-      moveToBeforeSpot.end = dayjs(moveToBeforeSpot.start)
-        .add(result.rows[0].elements[0].duration.value, 's')
-        .toDate()
-      moveToBeforeSpot.extendedProps.to = event.extendedProps.placeId
-      spotsApi.update({ ...moveToBeforeSpot })
+    const beforeSpot = spotsApi.getPrevSpot(selectedSpot)
+    // 直前に移動イベントがない場合は移動不可
+    if (!beforeSpot) {
+      console.log('cannot move up event')
+      return
     }
-
-    // 選択中のスポットイベントを直前のスポットイベントと入れ替える
-    const duration = dayjs(event.end).diff(event.start, 'minute')
-    const newStart = moveToBeforeSpot ? moveToBeforeSpot.end : beforeSpot.start
-    const newEnd = dayjs(newStart).add(duration, 'minute')
-    spotsApi.update({
-      ...(event.toJSON() as SpotEvent),
-      start: newStart,
-      end: newEnd.toDate(),
-      extendedProps: {
-        ...event.extendedProps,
-        from: beforeSpot.extendedProps.from,
-        to: beforeSpot.extendedProps.to,
-      },
-    })
-
-    // 移動イベントを入れ替えたスポットイベントに合わせて更新する
-    const moveDuration = dayjs(moveToSelected.end).diff(
-      moveToSelected.start,
-      'minute'
-    )
-    moveToSelected.start = newEnd.toDate()
-    moveToSelected.end = newEnd.add(moveDuration, 'minute').toDate()
-    spotsApi.update({
-      ...moveToSelected,
-      extendedProps: {
-        ...moveToSelected.extendedProps,
-        from: event.extendedProps.placeId,
-        to: beforeSpot.id,
-      },
-    })
-
-    // 入れ替える対象になる直前のイベントを更新する
-    const beforeDuration = dayjs(beforeSpot.end).diff(
-      beforeSpot.start,
-      'minute'
-    )
-    beforeSpot.start = moveToSelected.end
-    beforeSpot.end = dayjs(beforeSpot.start)
-      .add(beforeDuration, 'minute')
-      .toDate()
-    spotsApi.update({
-      ...beforeSpot,
-      extendedProps: {
-        ...beforeSpot.extendedProps,
-        from: event.extendedProps.from,
-        to: event.extendedProps.to,
-      },
-    })
-
-    // 選択したイベントより後のイベントを更新する
-    if (moveFromSelected) {
-      const org = [{ placeId: beforeSpot.id }]
-      const dest = [{ placeId: moveFromSelected.extendedProps.to }]
-      const result = await distanceMatrix.search(org, dest)
-
-      moveFromSelected.start = beforeSpot.end
-      const newMoveEnd = dayjs(moveFromSelected.start).add(
-        result.rows[0].elements[0].duration.value,
-        's'
-      )
-      const moveEndChange = newMoveEnd.diff(moveFromSelected.end, 'minute')
-      moveFromSelected.end = newMoveEnd.toDate()
-      moveFromSelected.extendedProps.from = beforeSpot.id
-      spotsApi.update({ ...moveFromSelected })
-
-      // 移動時間の変化量を、当日のその後のイベント全てに適用する
-
-      // Move イベントをたどって時刻の変更を適用する
-      spotsApi.applyChange(moveFromSelected, moveEndChange)
-    }
+    spotsApi.swap(beforeSpot, selectedSpot)
   }
 
   const handleDown = async () => {
     console.log('down')
-
-    const moveFromSelected = spots.find(
-      (spot): spot is MoveEvent =>
-        spot.extendedProps.type === 'move' &&
-        spot.extendedProps.from === event.id
-    )
-    const afterSpot = spots.find(
-      (spot): spot is SpotEvent =>
-        spot.id === moveFromSelected?.extendedProps.to
-    )
-
-    const moveFromAfter = spots.find(
-      (spot): spot is MoveEvent =>
-        spot.extendedProps.type === 'move' &&
-        spot.extendedProps.from === afterSpot?.id
-    )
-
-    // 直後に移動イベントがない場合は移動不可
-    if (moveFromSelected === undefined || afterSpot === undefined) {
-      console.log('cannot move down event')
+    const selectedSpot = spotsApi.get<SpotEvent>(event.id, 'spot')
+    if (selectedSpot === undefined) {
+      console.error('cannot find selected spot')
       return
     }
 
-    // 選択したスポットへの移動イベントを取得
-    const moveToSelected = spots.find(
-      (spot): spot is MoveEvent =>
-        spot.extendedProps.type === 'move' && spot.extendedProps.to === event.id
-    )
-
-    if (moveToSelected) {
-      // 直後のスポットへの移動イベントを選択中のイベントへの移動イベントに更新
-      const org = [{ placeId: moveToSelected.extendedProps.from }]
-      const dest = [{ placeId: afterSpot.id }]
-      const result = await distanceMatrix.search(org, dest)
-
-      moveToSelected.end = dayjs(moveToSelected.start)
-        .add(result.rows[0].elements[0].duration.value, 's')
-        .toDate()
-      moveToSelected.extendedProps.to = afterSpot.id
-      spotsApi.update({ ...moveToSelected })
+    const afterSpot = spotsApi.getNextSpot(selectedSpot)
+    // 直前に移動イベントがない場合は移動不可
+    if (!afterSpot) {
+      console.log('cannot move up event')
+      return
     }
-
-    // 直前のスポットイベントを選択中のイベントに入れ替える
-    const duration = dayjs(afterSpot.end).diff(afterSpot.start, 'minute')
-    afterSpot.start = moveToSelected
-      ? moveToSelected.end
-      : event.start || new Date()
-    afterSpot.end = dayjs(afterSpot.start).add(duration, 'minute').toDate()
-    spotsApi.update({
-      ...afterSpot,
-      extendedProps: {
-        ...afterSpot.extendedProps,
-        from: event.extendedProps.from,
-        to: event.extendedProps.to,
-      },
-    })
-
-    // 移動イベントを入れ替えたスポットイベントに合わせて更新する
-    const moveDuration = dayjs(moveFromSelected.end).diff(
-      moveFromSelected.start,
-      'minute'
-    )
-    moveFromSelected.start = afterSpot.end
-    moveFromSelected.end = dayjs(afterSpot.end)
-      .add(moveDuration, 'minute')
-      .toDate()
-    moveFromSelected.extendedProps.from = afterSpot.id
-    moveFromSelected.extendedProps.to = event.id
-    spotsApi.update({ ...moveFromSelected })
-
-    // 選択中のイベントを更新する
-    const eventDuration = dayjs(event.end).diff(event.start, 'minute')
-    const newStart = moveFromSelected.end
-    const newEnd = dayjs(newStart).add(eventDuration, 'minute').toDate()
-    spotsApi.update({
-      ...(event.toJSON() as SpotEvent),
-      start: newStart,
-      end: newEnd,
-      extendedProps: {
-        ...event.extendedProps,
-        from: afterSpot.from,
-        to: afterSpot.to,
-      },
-    })
-
-    // 選択したイベントより後のイベントを更新する
-    if (moveFromAfter) {
-      const org = [{ placeId: event.id }]
-      const dest = [{ placeId: moveFromAfter.extendedProps.to }]
-      const result = await distanceMatrix.search(org, dest)
-
-      moveFromAfter.start = newEnd
-      const newMoveEnd = dayjs(moveFromAfter.start).add(
-        result.rows[0].elements[0].duration.value,
-        's'
-      )
-      const moveEndChange = newMoveEnd.diff(moveFromAfter.end, 'minute')
-      moveFromAfter.end = newMoveEnd.toDate()
-      moveFromAfter.extendedProps.from = event.id
-      spotsApi.update({ ...moveFromAfter })
-
-      // Move イベントをたどって時刻の変更を適用する
-      spotsApi.applyChange(moveFromAfter, moveEndChange)
-    }
+    spotsApi.swap(selectedSpot, afterSpot)
   }
 
   const handleEdit = () => {

--- a/src/components/organisms/EventToolbar.tsx
+++ b/src/components/organisms/EventToolbar.tsx
@@ -28,8 +28,8 @@ const EventToolbar: React.FC<Props> = ({ event }) => {
     }
 
     const beforeSpot = spotsApi.getPrevSpot(selectedSpot)
-    // 直前に移動イベントがない場合は移動不可
-    if (!beforeSpot) {
+    // 直前のスポットがないもしくはホームの場合は移動不可
+    if (!beforeSpot || beforeSpot.id === 'start') {
       console.log('cannot move up event')
       return
     }
@@ -46,7 +46,7 @@ const EventToolbar: React.FC<Props> = ({ event }) => {
 
     const afterSpot = spotsApi.getNextSpot(selectedSpot)
     // 直前に移動イベントがない場合は移動不可
-    if (!afterSpot) {
+    if (!afterSpot || afterSpot.id === 'end') {
       console.log('cannot move up event')
       return
     }

--- a/src/components/organisms/MoveEventToolbar.tsx
+++ b/src/components/organisms/MoveEventToolbar.tsx
@@ -49,9 +49,12 @@ const MoveEventToolbar: React.FC<Props> = ({ event }) => {
       }
     }
 
+    const prev = actions.getPrevSpot(moveEvent)
+    const next = actions.getNextSpot(moveEvent)
+
     const result = await directions.search({
-      origin: { placeId: event.extendedProps.from },
-      destination: { placeId: event.extendedProps.to },
+      origin: { placeId: prev?.extendedProps.placeId },
+      destination: { placeId: next?.extendedProps.placeId },
       travelMode: travelMode(),
     })
 

--- a/src/components/organisms/SpotCard.tsx
+++ b/src/components/organisms/SpotCard.tsx
@@ -13,34 +13,24 @@ import { faInstagram } from '@fortawesome/free-brands-svg-icons'
 
 import { useGetSpotByPkLazyQuery } from 'generated/graphql'
 import { usePlaces } from 'hooks/usePlaces'
-import {
-  SelectedPlacesContext,
-  SpotEvent,
-} from 'contexts/SelectedPlacesProvider'
-import { useSelectSpots } from 'hooks/useSelectSpots'
+import { useSelectedSpots } from 'hooks/useSelectedSpots'
 
 type ButtonProps = {
   placeId: string
   photo: string
 }
 const SelectButton: React.FC<ButtonProps> = ({ placeId, photo }) => {
-  const selectedSpots = React.useContext(SelectedPlacesContext)
-  const { actions } = useSelectSpots()
+  const [, actions] = useSelectedSpots()
   const [loading, setLoading] = React.useState(false)
 
-  const selected = selectedSpots.find(
-    (spot): spot is SpotEvent =>
-      spot.extendedProps.type === 'spot' &&
-      spot.extendedProps?.placeId === placeId
-  )
+  const selected = actions.get(placeId)
 
-  const handleClick = async () => {
+  const handleClick = () => {
     setLoading(true)
-    console.log('click')
     if (selected) {
-      await actions.remove(selected)
+      actions.remove(placeId)
     } else {
-      await actions.add({ placeId, imageUrl: photo })
+      actions.add({ placeId, imageUrl: photo })
     }
     setLoading(false)
   }

--- a/src/components/organisms/SpotEventCard.tsx
+++ b/src/components/organisms/SpotEventCard.tsx
@@ -15,6 +15,9 @@ const SpotEventCard: React.FC<Props> = ({ event }) => {
   const [selected, setSelected] = React.useState(false)
 
   const handleClick = () => {
+    if (event.id === 'start' || event.id === 'end') {
+      return
+    }
     setSelected(true)
   }
 

--- a/src/components/organisms/SpotsCandidates.tsx
+++ b/src/components/organisms/SpotsCandidates.tsx
@@ -9,13 +9,13 @@ import SpotsList from './SpotsList'
 
 type Props = {
   open: boolean
-  places: Array<string>
+  placeIds: Array<string>
   onOpen: () => void
   onClose: () => void
 }
 const SpotsCandidates: React.FC<Props> = ({
   open,
-  places,
+  placeIds,
   onOpen,
   onClose,
 }) => {
@@ -56,7 +56,7 @@ const SpotsCandidates: React.FC<Props> = ({
               overflow: 'auto',
             }}>
             <Container maxWidth="xs">
-              <SpotsList spots={places} />
+              <SpotsList spots={placeIds} />
             </Container>
           </Box>
         </Box>

--- a/src/components/organisms/SpotsList.tsx
+++ b/src/components/organisms/SpotsList.tsx
@@ -9,8 +9,8 @@ type Props = {
 const SpotsList: React.FC<Props> = ({ spots }) => {
   return (
     <Stack spacing={2}>
-      {spots.map((spot) => (
-        <SpotCard key={spot} placeId={spot} />
+      {spots.map((spot, i) => (
+        <SpotCard key={`${i}-${spot}`} placeId={spot} />
       ))}
     </Stack>
   )

--- a/src/components/organisms/SpotsMap.tsx
+++ b/src/components/organisms/SpotsMap.tsx
@@ -11,8 +11,8 @@ import {
   GetSpotsByCategoryQuery,
   useGetSpotsByCategoryLazyQuery,
 } from 'generated/graphql'
-import SpotsList from './SpotsList'
 import { useMapProps } from 'hooks/useMapProps'
+import SpotCard from './SpotCard'
 
 const SpotsMap = () => {
   const [spots, setSpots] = React.useState<GetSpotsByCategoryQuery['spots']>([])
@@ -88,7 +88,7 @@ const SpotsMap = () => {
             maxWidth: '400px',
             maxHeight: '150px',
           }}>
-          <SpotsList spots={[focusedSpot]} />
+          <SpotCard placeId={focusedSpot} />
         </Box>
       )}
     </Box>

--- a/src/contexts/SelectedPlacesProvider.tsx
+++ b/src/contexts/SelectedPlacesProvider.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react'
-import { useList } from 'react-use'
-import { ListActions } from 'react-use/lib/useList'
 import { EventInput } from '@fullcalendar/react' // must go before plugins
+import { LinkedEventsActions, useLinkedEvents } from 'hooks/useLinkedEventList'
 
+export type SpotDTO = Required<Pick<Spot, 'placeId' | 'imageUrl'>>
 export type Spot = {
   type: 'spot'
   placeId: string
@@ -35,7 +35,7 @@ export const SelectedPlacesContext = React.createContext<Array<ScheduleEvent>>(
   []
 )
 const SelectedPlacesActionsContext =
-  React.createContext<ListActions<ScheduleEvent> | null>(null)
+  React.createContext<LinkedEventsActions<ScheduleEvent> | null>(null)
 
 export const useSelectedPlacesActions = () => {
   const actions = React.useContext(SelectedPlacesActionsContext)
@@ -47,9 +47,9 @@ export const useSelectedPlacesActions = () => {
 }
 
 export const SelectedPlacesProvider: React.FC = ({ children }) => {
-  const [places, actions] = useList<ScheduleEvent>()
+  const [events, actions] = useLinkedEvents<ScheduleEvent>()
   return (
-    <SelectedPlacesContext.Provider value={places}>
+    <SelectedPlacesContext.Provider value={events}>
       <SelectedPlacesActionsContext.Provider value={actions}>
         {children}
       </SelectedPlacesActionsContext.Provider>

--- a/src/contexts/SelectedSpotsProvider.tsx
+++ b/src/contexts/SelectedSpotsProvider.tsx
@@ -1,0 +1,20 @@
+import * as React from 'react'
+import { useList } from 'react-use'
+import { ListActions } from 'react-use/lib/useList'
+
+import { SpotDTO } from './SelectedPlacesProvider'
+
+export const SelectedSpotsContext = React.createContext<Array<SpotDTO>>([])
+export const SetSelectedSpotsContext =
+  React.createContext<ListActions<SpotDTO> | null>(null)
+
+export const SelectedSpotsProvider: React.FC = ({ children }) => {
+  const [selected, setSelected] = useList<SpotDTO>()
+  return (
+    <SelectedSpotsContext.Provider value={selected}>
+      <SetSelectedSpotsContext.Provider value={setSelected}>
+        {children}
+      </SetSelectedSpotsContext.Provider>
+    </SelectedSpotsContext.Provider>
+  )
+}

--- a/src/hooks/useDirections.ts
+++ b/src/hooks/useDirections.ts
@@ -33,6 +33,7 @@ export const useDirections = () => {
             }
           }
         )
+        console.log(result)
         return result
       } finally {
         setLoading(false)

--- a/src/hooks/useLinkedEventList.ts
+++ b/src/hooks/useLinkedEventList.ts
@@ -1,0 +1,164 @@
+import * as React from 'react'
+import { useList } from 'react-use'
+
+type Link = {
+  from: string | null
+  to: string | null
+}
+export type LinkedEvent = {
+  id: string
+  extendedProps: Link
+}
+
+export interface LinkedEventsActions<T extends LinkedEvent> {
+  push: (newItem: T) => void
+  get: (index: number) => T | null
+  getFirst: () => T | null
+  getLast: () => T | null
+  insert: (newItem: T, prevId: string) => void
+  remove: (newItem: T) => void
+  update: (newItem: T) => void
+  clear: () => void
+  next: (current: T) => T | null
+  prev: (current: T) => T | null
+}
+
+type UseLinkedList<T extends LinkedEvent> = readonly [
+  Array<T>,
+  LinkedEventsActions<T>
+]
+
+export const useLinkedEvents = <T extends LinkedEvent>(): UseLinkedList<T> => {
+  const [items, setItems] = useList<T>()
+  const itemsRef = React.useRef<T[]>([])
+  itemsRef.current = items
+
+  const getFirst = React.useCallback(() => {
+    return (
+      itemsRef.current.find((item) => item.extendedProps.from === null) || null
+    )
+  }, [])
+
+  const getLast = React.useCallback(() => {
+    return (
+      itemsRef.current.find((item) => item.extendedProps.to === null) || null
+    )
+  }, [])
+
+  const push = React.useCallback(
+    (newItem: T): void => {
+      const last = getLast()
+      if (last) {
+        // 末尾の要素にリンクを追加する
+        last.extendedProps.to = newItem.id
+        setItems.update((a, b) => a.id === last.id, { ...last })
+
+        setItems.push({
+          ...newItem,
+          extendedProps: {
+            ...newItem.extendedProps,
+            from: last.id,
+            to: null,
+          },
+        })
+      } else {
+        setItems.push(newItem)
+      }
+    },
+    [getLast, setItems]
+  )
+
+  const get = React.useCallback((index: number): T | null => {
+    return itemsRef.current[index] ?? null
+  }, [])
+
+  const next = React.useCallback((current: T): T | null => {
+    return (
+      itemsRef.current.find((item) => item.id === current.extendedProps.to) ||
+      null
+    )
+  }, [])
+
+  // const getAt = React.useCallback(
+  //   (index: number) => {
+  //     if (index >= itemsRef.current.length) {
+  //       return null
+  //     }
+
+  //     let item = getFirst()
+  //     for (let i = 0; i <= index; i++) {
+  //       if (item === null) {
+  //         break
+  //       }
+  //       item = next(item)
+  //     }
+  //     return item
+  //   },
+  //   [getFirst, next]
+  // )
+
+  const prev = React.useCallback((current: T): T | null => {
+    return (
+      itemsRef.current.find((item) => item.id === current.extendedProps.from) ||
+      null
+    )
+  }, [])
+
+  const insert = React.useCallback(
+    (newItem: T, targetId: string): void => {
+      const currentItem = itemsRef.current.find((item) => item.id === targetId)
+
+      const cloned = Object.create(newItem)
+
+      if (currentItem) {
+        currentItem.extendedProps.from = newItem.id
+        setItems.update((item) => item.id === currentItem.id, {
+          ...currentItem,
+        })
+
+        cloned.extendedProps.from = currentItem.extendedProps.from
+        cloned.extendedProps.to = currentItem.id
+        setItems.push({ ...cloned })
+      } else {
+        console.error('fail to insert')
+      }
+    },
+    [setItems]
+  )
+
+  const remove = React.useCallback(
+    (target: T): void => {
+      setItems.filter((item) => item.id !== target.id)
+    },
+    [setItems]
+  )
+
+  const update = React.useCallback(
+    (target: T): void => {
+      console.log(setItems)
+    },
+    [setItems]
+  )
+
+  const clear = React.useCallback((): void => {
+    console.log(setItems)
+  }, [setItems])
+
+  const actions = React.useMemo<LinkedEventsActions<T>>(
+    () => ({
+      push,
+      get,
+      getFirst,
+      getLast,
+      insert,
+      remove,
+      update,
+      clear,
+      next,
+      prev,
+    }),
+    [clear, get, getFirst, getLast, insert, next, prev, push, remove, update]
+  )
+
+  return [items, actions]
+}

--- a/src/hooks/useLinkedEventList.ts
+++ b/src/hooks/useLinkedEventList.ts
@@ -134,14 +134,14 @@ export const useLinkedEvents = <T extends LinkedEvent>(): UseLinkedList<T> => {
   )
 
   const update = React.useCallback(
-    (target: T): void => {
-      console.log(setItems)
+    (newItem: T): void => {
+      setItems.update((item) => item.id === newItem.id, newItem)
     },
     [setItems]
   )
 
   const clear = React.useCallback((): void => {
-    console.log(setItems)
+    setItems.clear()
   }, [setItems])
 
   const actions = React.useMemo<LinkedEventsActions<T>>(

--- a/src/hooks/useLinkedEventList.ts
+++ b/src/hooks/useLinkedEventList.ts
@@ -16,7 +16,7 @@ export interface LinkedEventsActions<T extends LinkedEvent> {
   getFirst: () => T | null
   getLast: () => T | null
   insert: (newItem: T, prevId: string) => void
-  remove: (newItem: T) => void
+  remove: (removedId: string) => void
   update: (newItem: T) => void
   clear: () => void
   next: (current: T) => T | null
@@ -127,8 +127,8 @@ export const useLinkedEvents = <T extends LinkedEvent>(): UseLinkedList<T> => {
   )
 
   const remove = React.useCallback(
-    (target: T): void => {
-      setItems.filter((item) => item.id !== target.id)
+    (removedId: string): void => {
+      setItems.filter((item) => item.id !== removedId)
     },
     [setItems]
   )

--- a/src/hooks/useSelectSpots.ts
+++ b/src/hooks/useSelectSpots.ts
@@ -35,7 +35,7 @@ const buildMoveEvent = ({
   return {
     id: createEventId(),
     title: 'Move',
-    color: 'white',
+    color: '#E5E3C9',
     display: 'background',
     ...eventProps,
     start,

--- a/src/hooks/useSelectedSpots.ts
+++ b/src/hooks/useSelectedSpots.ts
@@ -1,0 +1,62 @@
+import { ScheduleEvent, SpotEvent } from 'contexts/SelectedPlacesProvider'
+import { SelectedPrefectureContext } from 'contexts/SelectedPrefectureProvider'
+import {
+  SelectedSpotsContext,
+  SetSelectedSpotsContext,
+} from 'contexts/SelectedSpotsProvider'
+import * as React from 'react'
+
+export const useSelectedSpots = () => {
+  const spots = React.useContext(SelectedSpotsContext)
+  const spotsActions = React.useContext(SetSelectedSpotsContext)
+  if (spotsActions === null) {
+    throw Error('SelectedSpotsProvider is not wrapped')
+  }
+  const { home } = React.useContext(SelectedPrefectureContext)
+
+  const init = React.useCallback(
+    (events: Array<ScheduleEvent>) => {
+      spotsActions.set(
+        events
+          .filter(
+            (event): event is SpotEvent =>
+              event.extendedProps.type === 'spot' &&
+              event.extendedProps.placeId !== home?.place_id
+          )
+          .map((event) => ({
+            placeId: event.extendedProps.placeId,
+            imageUrl: event.extendedProps.imageUrl,
+          }))
+      )
+    },
+    [home?.place_id, spotsActions]
+  )
+
+  const add = React.useCallback(
+    (newSpot: typeof spots[number]) => {
+      spotsActions.push(newSpot)
+    },
+    [spotsActions]
+  )
+
+  const remove = React.useCallback(
+    (removedId: string) => {
+      spotsActions.filter((spot) => spot.placeId !== removedId)
+    },
+    [spotsActions]
+  )
+
+  const get = React.useCallback(
+    (placeId: string) => {
+      return spots.find((spot) => spot.placeId === placeId)
+    },
+    [spots]
+  )
+
+  const actions = React.useMemo(
+    () => ({ add, get, init, remove }),
+    [add, get, init, remove]
+  )
+
+  return [spots, actions] as const
+}


### PR DESCRIPTION
close #73 

ホームを取り入れたルートを生成
ホームをイベント内に入れるためにいくつかリファクタリングをした

- 同一イベントを保持できるように、イベントIDに Place ID 以外を設定
- ルート検索時に必ず extendedProps の Place ID を参照
- イベントのリストを双方向リストとして定義
- フック内に便利な関数を追加