### PR TITLE
Feat/119 update map center

### DIFF
--- a/src/components/modules/CategorySelector.tsx
+++ b/src/components/modules/CategorySelector.tsx
@@ -12,7 +12,7 @@ import FormLabel from '@mui/material/FormLabel'
 import { useGetCategoriesQuery } from 'generated/graphql'
 
 type Props = {
-  onChange?: (value: number) => void
+  onChange?: (value: number | null) => void
 }
 const CategorySelector: React.FC<Props> = ({ onChange: changedCallback }) => {
   const [selectedId, setSelectedId] = React.useState<number | null>(null)
@@ -27,9 +27,7 @@ const CategorySelector: React.FC<Props> = ({ onChange: changedCallback }) => {
   }
 
   React.useEffect(() => {
-    if (selectedId) {
-      changedCallback?.(selectedId)
-    }
+    changedCallback?.(selectedId)
     // not update callback when mapBounds is changed
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [selectedId])
@@ -45,6 +43,10 @@ const CategorySelector: React.FC<Props> = ({ onChange: changedCallback }) => {
   React.useEffect(() => {
     if (data?.categories && data.categories.length > 0) {
       setSelectedId(data.categories[0].id || 0)
+    }
+
+    return () => {
+      setSelectedId(null)
     }
   }, [data?.categories])
 

--- a/src/components/modules/GoogleMap.tsx
+++ b/src/components/modules/GoogleMap.tsx
@@ -59,20 +59,27 @@ const GoogleMap: React.FC = React.memo(function Map({ children }) {
 
     const bounds = mapInstance.getBounds()
 
-    if (plan) {
-      const { lat, lng, zoom } = plan.destination
-      setMapProps((prev) => ({
-        center: { lat, lng } || prev.center,
-        zoom: zoom || prev.zoom,
-        bounds: {
-          ne: bounds?.getNorthEast(),
-          sw: bounds?.getSouthWest(),
-        },
-      }))
-    }
+    setMapProps((prev) => ({
+      ...prev,
+      bounds: {
+        ne: bounds?.getNorthEast(),
+        sw: bounds?.getSouthWest(),
+      },
+    }))
 
     setGoogleMap(mapInstance)
   }
+
+  React.useEffect(() => {
+    if (plan) {
+      const { lat, lng, zoom } = plan.destination
+      setMapProps((prev) => ({
+        ...prev,
+        center: { lat, lng } || prev.center,
+        zoom: zoom || prev.zoom,
+      }))
+    }
+  }, [plan, setMapProps])
 
   if (loadError) {
     console.log('Error has occurred when loading google map')

--- a/src/components/modules/GoogleMap.tsx
+++ b/src/components/modules/GoogleMap.tsx
@@ -39,6 +39,9 @@ const GoogleMap: React.FC<Props> = React.memo(function Map({
   const setDistanceMatrix = React.useContext(SetDistanceMatrixContext)
   const setPlaces = React.useContext(SetPlacesServiceContext)
 
+  /**
+   * マップ操作が終了したタイミングで、center などのプロパティを更新する
+   */
   const handleIdled = () => {
     console.log(googleMap)
     if (googleMap) {
@@ -81,6 +84,7 @@ const GoogleMap: React.FC<Props> = React.memo(function Map({
   }
 
   React.useEffect(() => {
+    // 選択しているプランの目的地を中心にする
     if (plan) {
       const { lat, lng, zoom } = plan.destination
       setMapProps((prev) => ({

--- a/src/components/modules/GoogleMap.tsx
+++ b/src/components/modules/GoogleMap.tsx
@@ -18,7 +18,13 @@ const containerStyle = {
 
 const libs: 'places'[] = ['places']
 
-const GoogleMap: React.FC = React.memo(function Map({ children }) {
+type Props = {
+  onLoad?: (map: google.maps.Map) => void
+}
+const GoogleMap: React.FC<Props> = React.memo(function Map({
+  children,
+  onLoad,
+}) {
   const { isLoaded, loadError } = useLoadScript({
     googleMapsApiKey: googleMapConfigs.apiKey,
     libraries: libs,
@@ -34,8 +40,10 @@ const GoogleMap: React.FC = React.memo(function Map({ children }) {
   const setPlaces = React.useContext(SetPlacesServiceContext)
 
   const handleIdled = () => {
+    console.log(googleMap)
     if (googleMap) {
       const bounds = googleMap.getBounds()
+      console.log(bounds)
 
       setMapProps((prev) => ({
         center: googleMap.getCenter() || prev.center,
@@ -51,7 +59,8 @@ const GoogleMap: React.FC = React.memo(function Map({ children }) {
   // wrapping to a function is useful in case you want to access `window.google`
   // to eg. setup options or create latLng object, it won't be available otherwise
   // feel free to render directly if you don't need that
-  const onLoad = (mapInstance: google.maps.Map) => {
+  const handleLoad = (mapInstance: google.maps.Map) => {
+    console.log('loaded')
     // do something with map Instance
     setDirectionService(new window.google.maps.DirectionsService())
     setDistanceMatrix(new window.google.maps.DistanceMatrixService())
@@ -68,6 +77,7 @@ const GoogleMap: React.FC = React.memo(function Map({ children }) {
     }))
 
     setGoogleMap(mapInstance)
+    onLoad?.(mapInstance)
   }
 
   React.useEffect(() => {
@@ -75,8 +85,8 @@ const GoogleMap: React.FC = React.memo(function Map({ children }) {
       const { lat, lng, zoom } = plan.destination
       setMapProps((prev) => ({
         ...prev,
-        center: { lat, lng } || prev.center,
-        zoom: zoom || prev.zoom,
+        center: { lat, lng },
+        zoom: zoom,
       }))
     }
   }, [plan, setMapProps])
@@ -86,6 +96,7 @@ const GoogleMap: React.FC = React.memo(function Map({ children }) {
   }
 
   if (isLoaded === false) {
+    console.log('loading')
     return <>Now loading...</>
   }
 
@@ -102,7 +113,7 @@ const GoogleMap: React.FC = React.memo(function Map({ children }) {
       center={mapProps.center}
       zoom={mapProps.zoom}
       onIdle={handleIdled}
-      onLoad={onLoad}>
+      onLoad={handleLoad}>
       {/* Child components, such as markers, info windows, etc. */}
       {children}
     </GoogleMapLib>

--- a/src/components/modules/SpotsByCategory.tsx
+++ b/src/components/modules/SpotsByCategory.tsx
@@ -1,0 +1,70 @@
+import * as React from 'react'
+
+import {
+  GetSpotsByCategoryQuery,
+  useGetSpotsByCategoryLazyQuery,
+} from 'generated/graphql'
+
+import PlaceMarker from './PlaceMarker'
+import { useMapProps } from 'hooks/googlemaps/useMapProps'
+
+type Props = {
+  categoryId: number | null
+  focusedSpot: string
+  onClick: (placeId: string) => void
+}
+const SpotsByCategory: React.FC<Props> = ({
+  categoryId,
+  focusedSpot,
+  onClick,
+}) => {
+  const [spots, setSpots] = React.useState<GetSpotsByCategoryQuery['spots']>([])
+  const [getSpots] = useGetSpotsByCategoryLazyQuery()
+  const [mapProps] = useMapProps()
+
+  React.useEffect(() => {
+    if (spots.length > 0) {
+      return
+    }
+    const bounds = mapProps.bounds
+    const northEast = bounds?.ne
+    const southWest = bounds?.sw
+    if (northEast && southWest && categoryId) {
+      getSpots({
+        variables: {
+          categoryId,
+          north: northEast.lat(),
+          east: northEast.lng(),
+          south: southWest.lat(),
+          west: southWest.lng(),
+        },
+      })
+        .then((results) => {
+          if (results.error) {
+            console.error(`Fail to fetch types by category id ${categoryId}`)
+          }
+          setSpots(results.data?.spots || [])
+        })
+        .catch((error) => {
+          console.error(error)
+        })
+    }
+  }, [categoryId, getSpots, mapProps.bounds, spots.length])
+
+  return (
+    <>
+      {spots.map((item) => (
+        <PlaceMarker
+          key={item.place_id}
+          placeId={item.place_id}
+          selected={item.place_id === focusedSpot}
+          lat={item.lat}
+          lng={item.lng}
+          onClick={onClick}
+        />
+      ))}
+    </>
+  )
+}
+
+export default SpotsByCategory

--- a/src/components/modules/SpotsByCategory.tsx
+++ b/src/components/modules/SpotsByCategory.tsx
@@ -24,6 +24,7 @@ const SpotsByCategory: React.FC<Props> = ({
 
   React.useEffect(() => {
     if (spots.length > 0) {
+      // マップが移動するたびに何度も Fetch することを防ぐ
       return
     }
     const bounds = mapProps.bounds

--- a/src/components/modules/SpotsMap.tsx
+++ b/src/components/modules/SpotsMap.tsx
@@ -5,48 +5,20 @@ import { useClickAway } from 'react-use'
 
 import CategorySelector from './CategorySelector'
 import GoogleMap from './GoogleMap'
-import PlaceMarker from './PlaceMarker'
 import SearchBox from './SearchBox'
-import {
-  GetSpotsByCategoryQuery,
-  useGetSpotsByCategoryLazyQuery,
-} from 'generated/graphql'
-import { useMapProps } from 'hooks/googlemaps/useMapProps'
 import SpotCard from './SpotCard'
+import SpotsByCategory from './SpotsByCategory'
 
 const SpotsMap = () => {
-  const [spots, setSpots] = React.useState<GetSpotsByCategoryQuery['spots']>([])
-  const [getSpots] = useGetSpotsByCategoryLazyQuery()
-  const [mapProps] = useMapProps()
-
   const spotCardRef = React.useRef<HTMLDivElement>(null)
+  const [selectedCategory, setSelectedCategory] = React.useState<number | null>(
+    null
+  )
   useClickAway(spotCardRef, () => {
     setFocusedSpot('')
   })
 
   const [focusedSpot, setFocusedSpot] = React.useState('')
-
-  const handleSelectCategory = React.useCallback(
-    async (id: number) => {
-      const mapBounds = mapProps.bounds
-      if (mapBounds?.ne && mapBounds?.sw) {
-        const results = await getSpots({
-          variables: {
-            categoryId: id,
-            north: mapBounds.ne.lat(),
-            south: mapBounds.sw.lat(),
-            west: mapBounds.sw.lng(),
-            east: mapBounds.ne.lng(),
-          },
-        })
-        if (results.error) {
-          console.error(`Fail to fetch types by category id ${id}`)
-        }
-        setSpots(results.data?.spots || [])
-      }
-    },
-    [getSpots, mapProps.bounds]
-  )
 
   const handleMarkerClicked = (placeId: string) => {
     setFocusedSpot(placeId)
@@ -55,23 +27,16 @@ const SpotsMap = () => {
   return (
     <Box sx={{ position: 'relative', width: '100%', height: '100%' }}>
       <GoogleMap>
-        <>
-          {spots.map((item) => (
-            <PlaceMarker
-              key={item.place_id}
-              placeId={item.place_id}
-              selected={item.place_id === focusedSpot}
-              lat={item.lat}
-              lng={item.lng}
-              onClick={handleMarkerClicked}
-            />
-          ))}
-        </>
+        <SpotsByCategory
+          categoryId={selectedCategory}
+          focusedSpot={focusedSpot}
+          onClick={handleMarkerClicked}
+        />
       </GoogleMap>
       <Box sx={{ position: 'absolute', left: 0, top: 0, ml: 2, mt: 2 }}>
         <Stack direction="row" spacing={1} alignItems="center">
           <SearchBox />
-          <CategorySelector onChange={handleSelectCategory} />
+          <CategorySelector onChange={setSelectedCategory} />
         </Stack>
       </Box>
       {focusedSpot && (


### PR DESCRIPTION
close #119 

- プランの選択を切り替えた際に、Google Map の表示が前回選択したプランに影響される問題を修正
  - プランが選択されたら MapCenter と zoom レベルを更新
  - Map 画面が開かれるたびに、現在の描画範囲で Spots リストを Fetch する