### PR TITLE
FIX: Update plan when used by guest

### DIFF
--- a/src/hooks/usePlan.ts
+++ b/src/hooks/usePlan.ts
@@ -85,8 +85,10 @@ export const usePlan = () => {
           if (user && plan) {
             const path = PLANING_USERS_PLANS_COLLECTIONS(user.uid)
             await db.set(path, plan.id, updatedPlan)
-            setPlan({ type: 'update', value: updatedPlan })
           }
+
+          // Guest user でも Plan が更新されるように、DB 周りとは隔離して更新する
+          setPlan({ type: 'update', value: updatedPlan })
         } catch (e) {
           console.error(e)
         }


### PR DESCRIPTION
Close #118

Guest ユーザーが使用するときに、Route 生成が行われない問題を修正
→プランの更新処理がログインしている時しか行っていなかったので、未ログインでも実行されるようにした