### PR TITLE
fix/136-day-header

### DIFF
--- a/src/components/modules/EventsScheduler.tsx
+++ b/src/components/modules/EventsScheduler.tsx
@@ -228,15 +228,7 @@ const EventsScheduler: React.FC<Props> = ({ plan, planApi }) => {
   }
 
   const renderDayHeader = (props: DayHeaderContentArg) => {
-    const yesterday = dayjs()
-      .add(-1, 'day')
-      .hour(0)
-      .minute(0)
-      .second(0)
-      .millisecond(0)
-    const diff = dayjs(props.date).diff(yesterday, 'day')
-
-    return `Day ${diff}`
+    return dayjs(props.date).format('MM/DD (ddd)')
   }
 
   return (

--- a/src/pages/new.tsx
+++ b/src/pages/new.tsx
@@ -73,8 +73,8 @@ const PrefectureSelector = () => {
       const newPlan: Parameters<typeof createPlan>[number] = {
         title: planDTO.title,
         start: planDTO.start,
-        startTime: dayjs('08:30:00', 'HH:mm:ss').toDate(),
-        end: planDTO.start,
+        startTime: dayjs(planDTO.start).hour(8).minute(30).second(0).toDate(),
+        end: dayjs(planDTO.start).hour(8).minute(30).second(0).toDate(),
         thumbnail: destPhoto,
         home: { ...planDTO.home, imageUrl: homePhoto },
         destination: { ...planDTO.destination, imageUrl: destPhoto },


### PR DESCRIPTION
close #136 

- Day Header が -1 とかになってしまう問題を修正
  - イベントの日付が、イベントを作成した日に依存していた
    - プラン作成時に、イベント開始時刻をToday基準にしていたため
    - イベント開始時刻を旅行開始日の朝にするよう修正