### PR TITLE
FIX: Move to home after delete plan

### DIFF
--- a/src/components/layouts/PlanView.tsx
+++ b/src/components/layouts/PlanView.tsx
@@ -1,12 +1,30 @@
 import * as React from 'react'
 import Stack from '@mui/material/Stack'
+import Typography from '@mui/material/Typography'
+import Link from 'next/link'
 
 import SpotsMap from 'components/modules/SpotsMap'
 import PlanningLayout from 'components/layouts/PlaningLayout'
 import MapToolbar from 'components/modules/MapToolbar'
 import { MapLayerProvider } from 'contexts/MapLayerModeProvider'
+import { useTravelPlan } from 'hooks/useTravelPlan'
+import { useRouter } from 'hooks/useRouter'
 
 const PlanView = () => {
+  const router = useRouter()
+  const [plan] = useTravelPlan()
+
+  if (!plan) {
+    return (
+      <PlanningLayout>
+        <Stack alignItems="center" py={6} spacing={3}>
+          <Typography variant="h2">Plan is not exist</Typography>
+          <Link href={router.home}>Back to home</Link>
+        </Stack>
+      </PlanningLayout>
+    )
+  }
+
   return (
     <PlanningLayout>
       <Stack

--- a/src/components/modules/PlanMenu.tsx
+++ b/src/components/modules/PlanMenu.tsx
@@ -9,6 +9,7 @@ import { useConfirm } from 'hooks/useConfirm'
 import { useTravelPlan } from 'hooks/useTravelPlan'
 import { useAsyncFn } from 'react-use'
 import { useMapLayer } from 'contexts/MapLayerModeProvider'
+import { useRouter } from 'hooks/useRouter'
 
 type Props = MenuProps & {
   addHotelCallback?: () => void
@@ -17,6 +18,7 @@ const PlanMenu: React.FC<Props> = ({ addHotelCallback, ...props }) => {
   const [, planApi] = useTravelPlan()
   const confirm = useConfirm()
   const [, setMode] = useMapLayer()
+  const router = useRouter()
 
   const [{ loading }, handleOptimize] = useAsyncFn(async () => {
     try {
@@ -52,6 +54,7 @@ const PlanMenu: React.FC<Props> = ({ addHotelCallback, ...props }) => {
         description: '旅行プランが完全に削除されます。よろしいですか?',
       })
       await planApi.delete()
+      router.userHome()
     } finally {
       props.onClose?.({}, 'backdropClick')
     }

--- a/src/pages/[userId]/[planId].tsx
+++ b/src/pages/[userId]/[planId].tsx
@@ -10,7 +10,7 @@ const PlanPage = () => {
   const { userId, planId } = router.query
   const { get: getPlan } = usePlans()
 
-  const [plan, planApi] = useTravelPlan()
+  const [, planApi] = useTravelPlan()
 
   React.useEffect(() => {
     const func = async () => {
@@ -19,7 +19,6 @@ const PlanPage = () => {
           .then((target) => {
             if (!target) {
               console.error(`Plan is not exist. ID: ${planId}`)
-              router.userHome(true)
               return
             }
             planApi.set(planId, target)
@@ -37,10 +36,6 @@ const PlanPage = () => {
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [planId, userId])
-
-  if (!plan) {
-    return <></>
-  }
 
   return <PlanView />
 }

--- a/src/pages/plan.tsx
+++ b/src/pages/plan.tsx
@@ -1,19 +1,8 @@
 import * as React from 'react'
 
-import { useTravelPlan } from 'hooks/useTravelPlan'
-import { useRouter } from 'hooks/useRouter'
 import PlanView from 'components/layouts/PlanView'
 
 const FeaturedPlaces = () => {
-  const router = useRouter()
-  const [plan] = useTravelPlan()
-
-  React.useEffect(() => {
-    if (!plan) {
-      router.userHome(true)
-    }
-  }, [plan, router])
-
   return <PlanView />
 }
 


### PR DESCRIPTION
close #145 

プラン削除時にホーム画面に遷移するようにした

## なぜ?

プラン削除後に画面遷移がなかったため、削除後に真っ白な画面が表示され操作性が損なわれていたため