### PR TITLE
Feat/163 set start end

### DIFF
--- a/src/components/layouts/PlaningLayout.tsx
+++ b/src/components/layouts/PlaningLayout.tsx
@@ -32,8 +32,10 @@ const PlanningLayout: React.FC = () => {
   const routesApi = useRoutes()
 
   React.useEffect(() => {
+    // とりあえずページアクセス時にキャッシュを削除するようにする
     console.log('clean routes cache')
     routesApi.clean()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
   const handleChange = (event: React.SyntheticEvent, newValue: number) => {

--- a/src/components/layouts/PlaningLayout.tsx
+++ b/src/components/layouts/PlaningLayout.tsx
@@ -20,6 +20,7 @@ import PlanView from './PlanView'
 import TabPanel from 'components/modules/TabPanel'
 import { MapLayerProvider } from 'contexts/MapLayerModeProvider'
 import ScheduleListView from './ScheduleListView'
+import { useRoutes } from 'hooks/useRoutes'
 
 const MyTab = styled(Tab)`
   padding: 0;
@@ -27,18 +28,16 @@ const MyTab = styled(Tab)`
 `
 
 const PlanningLayout: React.FC = () => {
-  const [isMounted, setIsMounted] = React.useState(false)
   const [value, setValue] = React.useState(1)
+  const routesApi = useRoutes()
+
+  React.useEffect(() => {
+    console.log('clean routes cache')
+    routesApi.clean()
+  }, [])
 
   const handleChange = (event: React.SyntheticEvent, newValue: number) => {
     setValue(newValue)
-  }
-  React.useEffect(() => {
-    setIsMounted(true)
-  }, [])
-
-  if (!isMounted) {
-    return null
   }
 
   return (

--- a/src/components/modules/DayHeader.tsx
+++ b/src/components/modules/DayHeader.tsx
@@ -7,6 +7,8 @@ import Typography from '@mui/material/Typography'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faEllipsisVertical } from '@fortawesome/free-solid-svg-icons'
 
+import TimePicker from './TimePicker'
+
 type Props = {
   day: number
   onOpenMenu: (anchor: HTMLElement) => void
@@ -14,7 +16,12 @@ type Props = {
 const DayHeader: React.FC<Props> = ({ day, onOpenMenu }) => {
   return (
     <Stack direction="row" alignItems="center" justifyContent="space-between">
-      <Typography>Day {day}</Typography>
+      <Stack direction="row" spacing={1} alignItems="center">
+        <Typography>Day {day}</Typography>
+        <TimePicker type="text" />
+        <Typography> ~ </Typography>
+        <TimePicker type="text" />
+      </Stack>
       <Box>
         <IconButton onClick={(e) => onOpenMenu(e.currentTarget)}>
           <SvgIcon>

--- a/src/components/modules/DayHeader.tsx
+++ b/src/components/modules/DayHeader.tsx
@@ -7,20 +7,54 @@ import Typography from '@mui/material/Typography'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faEllipsisVertical } from '@fortawesome/free-solid-svg-icons'
 
-import TimePicker from './TimePicker'
+import TimePicker, { Time } from './TimePicker'
+import { useTravelPlan } from 'hooks/useTravelPlan'
+import dayjs from 'dayjs'
+
+const fromMidnight = (date: Date) => date.getHours() * 60 + date.getMinutes()
 
 type Props = {
   day: number
   onOpenMenu: (anchor: HTMLElement) => void
 }
 const DayHeader: React.FC<Props> = ({ day, onOpenMenu }) => {
+  const [plan, planApi] = useTravelPlan()
+  const event = plan?.events[day - 1]
+
+  const handleChange = React.useCallback(
+    (value: Time) => {
+      planApi.update({
+        events: plan?.events.map((event, i) => {
+          if (i === day - 1) {
+            return {
+              ...event,
+              start: dayjs(event.start)
+                .hour(value.hour)
+                .minute(value.minute)
+                .toDate(),
+            }
+          } else {
+            return event
+          }
+        }),
+      })
+    },
+    [day, plan?.events, planApi]
+  )
+
+  if (!event) {
+    return <></>
+  }
   return (
     <Stack direction="row" alignItems="center" justifyContent="space-between">
       <Stack direction="row" spacing={1} alignItems="center">
         <Typography>Day {day}</Typography>
-        <TimePicker type="text" />
-        <Typography> ~ </Typography>
-        <TimePicker type="text" />
+        <TimePicker
+          type="text"
+          label="開始時刻 : "
+          value={fromMidnight(event.start)}
+          onChange={handleChange}
+        />
       </Stack>
       <Box>
         <IconButton onClick={(e) => onOpenMenu(e.currentTarget)}>

--- a/src/components/modules/ListScheduler.tsx
+++ b/src/components/modules/ListScheduler.tsx
@@ -10,14 +10,15 @@ import {
   DroppableProvided,
   DropResult,
 } from 'react-beautiful-dnd'
+import dayjs from 'dayjs'
 
+import DayHeader from './DayHeader'
 import DayMenu from './DayMenu'
-import { useTravelPlan } from 'hooks/useTravelPlan'
+import Route from './Route'
 import SpotEventCard from './SpotEventCard'
 import SpotEventEditor from './SpotEventEditor'
 import { Spot } from 'contexts/CurrentPlanProvider'
-import Route from './Route'
-import DayHeader from './DayHeader'
+import { useTravelPlan } from 'hooks/useTravelPlan'
 
 const reorder = <T,>(list: T[], startIndex: number, endIndex: number): T[] => {
   const result = Array.from(list)
@@ -82,13 +83,21 @@ const ListScheduler: React.FC = () => {
           ),
         })
       } else if (destination.droppableId === 'newDay') {
+        // Add a new day
         const [removedSpot] = plan.events[
           Number.parseInt(source.droppableId)
         ].spots.splice(source.index, 1)
+
+        const newDate = dayjs(plan.events.slice(-1)[0].start)
+          .add(1, 'day')
+          .hour(9)
+          .minute(0)
         planApi.update({
           events: [
             ...plan.events,
             {
+              start: newDate.toDate(),
+              end: newDate.hour(19).toDate(),
               spots: [removedSpot],
             },
           ],

--- a/src/components/modules/ListScheduler.tsx
+++ b/src/components/modules/ListScheduler.tsx
@@ -173,7 +173,14 @@ const ListScheduler: React.FC = () => {
                                       {...provided.dragHandleProps}
                                       {...provided.draggableProps}>
                                       <Box onClick={() => setEditSpot(spot)}>
-                                        <SpotEventCard spot={spot} />
+                                        <SpotEventCard
+                                          spot={spot}
+                                          prevSpots={event.spots.slice(
+                                            0,
+                                            index
+                                          )}
+                                          dayStart={event.start}
+                                        />
                                       </Box>
                                       {index !== event.spots.length - 1 && (
                                         <Box py={0.5}>

--- a/src/components/modules/Route.tsx
+++ b/src/components/modules/Route.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react'
+import Box from '@mui/material/Box'
 import CircularProgress from '@mui/material/CircularProgress'
 import Collapse from '@mui/material/Collapse'
 import IconButton from '@mui/material/IconButton'
@@ -99,7 +100,13 @@ const Route: React.FC<Props> = ({ origin, dest }) => {
   return (
     <Stack direction="row" alignItems="center" px={3}>
       <Stack direction="row" alignItems="center" sx={{ flexGrow: 1 }}>
-        <IconButton onClick={handleClick(selected)} size="small">
+        <IconButton
+          onClick={handleClick(selected)}
+          size="small"
+          sx={{
+            background: (theme) =>
+              selecting ? theme.palette.grey[300] : undefined,
+          }}>
           <SvgIcon>
             <FontAwesomeIcon icon={modes[selected]} />
           </SvgIcon>
@@ -117,11 +124,13 @@ const Route: React.FC<Props> = ({ origin, dest }) => {
               ))}
           </Stack>
         </Collapse>
-        {loading ? (
-          <CircularProgress />
-        ) : (
-          <Typography variant="body2">{time}</Typography>
-        )}
+        <Box pl={1}>
+          {loading ? (
+            <CircularProgress />
+          ) : (
+            <Typography variant="body2">{time}</Typography>
+          )}
+        </Box>
       </Stack>
       <IconButton
         size="small"

--- a/src/components/modules/Route.tsx
+++ b/src/components/modules/Route.tsx
@@ -39,7 +39,7 @@ type Props = {
 const Route: React.FC<Props> = ({ origin, dest }) => {
   const [selecting, setSelecting] = React.useState(false)
   const [selected, setSelected] = React.useState<TravelMode>(
-    origin.mode || 'driving'
+    origin.next?.mode || 'driving'
   )
 
   const routesApi = useRoutes()
@@ -61,11 +61,13 @@ const Route: React.FC<Props> = ({ origin, dest }) => {
   }
 
   React.useEffect(() => {
-    if (origin.mode !== selected) {
+    if (origin.next?.mode !== selected) {
       console.log('update travel mode')
-      waypointsApi.update(origin.id, { mode: selected })
+      waypointsApi.update(origin.id, {
+        next: { id: dest.id, mode: selected },
+      })
     }
-  }, [origin.id, origin.mode, selected, waypointsApi])
+  }, [dest.id, origin.id, origin.next, selected, waypointsApi])
 
   React.useEffect(() => {
     const routeCache = routesApi.get({
@@ -75,7 +77,7 @@ const Route: React.FC<Props> = ({ origin, dest }) => {
     })
     if (routeCache?.time) {
       console.log('use route cache')
-      setTime(routeCache.time)
+      setTime(routeCache.time.text)
     } else {
       search({
         origin,
@@ -88,7 +90,7 @@ const Route: React.FC<Props> = ({ origin, dest }) => {
           from: origin.id,
           to: dest.id,
           mode: selected,
-          time: result?.legs[0].duration.text,
+          time: result && { ...result.legs[0].duration, unit: 'second' },
         })
       })
     }

--- a/src/components/modules/SpotEventCard.tsx
+++ b/src/components/modules/SpotEventCard.tsx
@@ -19,6 +19,7 @@ const SpotEventCard: React.FC<Props> = ({ spot, prevSpots, dayStart }) => {
   const start = () => {
     let _start = dayjs(dayStart)
     prevSpots.forEach((prev) => {
+      // このスポットよりも前にスケジュールされているスポットの滞在時間と移動時間を加算
       const nextRoute =
         prev.next &&
         routesApi.get({
@@ -26,7 +27,6 @@ const SpotEventCard: React.FC<Props> = ({ spot, prevSpots, dayStart }) => {
           to: prev.next.id,
           mode: prev.next.mode,
         })
-      console.log(nextRoute)
       _start = dayjs(_start)
         .add(prev.duration, prev.durationUnit)
         .add(nextRoute?.time?.value || 0, nextRoute?.time?.unit)

--- a/src/components/modules/SpotEventCard.tsx
+++ b/src/components/modules/SpotEventCard.tsx
@@ -7,12 +7,34 @@ import Typography from '@mui/material/Typography'
 
 import { Spot } from 'contexts/CurrentPlanProvider'
 import dayjs from 'dayjs'
+import { useRoutes } from 'hooks/useRoutes'
 
 type Props = {
   spot: Spot
+  prevSpots: Array<Spot>
+  dayStart: Date
 }
-const SpotEventCard: React.FC<Props> = ({ spot }) => {
-  const start = new Date()
+const SpotEventCard: React.FC<Props> = ({ spot, prevSpots, dayStart }) => {
+  const routesApi = useRoutes()
+  const start = () => {
+    let _start = dayjs(dayStart)
+    prevSpots.forEach((prev) => {
+      const nextRoute =
+        prev.next &&
+        routesApi.get({
+          from: prev.id,
+          to: prev.next.id,
+          mode: prev.next.mode,
+        })
+      console.log(nextRoute)
+      _start = dayjs(_start)
+        .add(prev.duration, prev.durationUnit)
+        .add(nextRoute?.time?.value || 0, nextRoute?.time?.unit)
+    })
+
+    return _start
+  }
+
   return (
     <Box
       sx={{
@@ -27,7 +49,7 @@ const SpotEventCard: React.FC<Props> = ({ spot }) => {
               alignItems="center"
               height="100%">
               <Typography variant="subtitle1">
-                {dayjs(start).format('HH:mm')}
+                {start().format('HH:mm')}
               </Typography>
               <Box
                 flexGrow={1}
@@ -38,9 +60,7 @@ const SpotEventCard: React.FC<Props> = ({ spot }) => {
                 }}
               />
               <Typography variant="subtitle1">
-                {dayjs(start)
-                  .add(spot.duration, spot.durationUnit)
-                  .format('HH:mm')}
+                {start().add(spot.duration, spot.durationUnit).format('HH:mm')}
               </Typography>
             </Stack>
           </Grid>

--- a/src/components/modules/SpotEventEditor.tsx
+++ b/src/components/modules/SpotEventEditor.tsx
@@ -62,7 +62,12 @@ const SpotEventEditor: React.FC<Props> = ({ spotId, ...props }) => {
                 control={control}
                 name="duration"
                 render={({ field }) => (
-                  <TimePicker value={field.value} onChange={field.onChange} />
+                  <TimePicker
+                    value={field.value}
+                    onChange={(time) =>
+                      field.onChange(time.hour * 60 + time.minute)
+                    }
+                  />
                 )}
               />
             </Stack>

--- a/src/components/modules/TimePicker.tsx
+++ b/src/components/modules/TimePicker.tsx
@@ -155,6 +155,7 @@ const TimeSelector: React.FC<Props> = ({
       onChange?.(time)
     }
     mounted.current = true
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [time])
 
   const display = () => {

--- a/src/components/modules/TimePicker.tsx
+++ b/src/components/modules/TimePicker.tsx
@@ -41,6 +41,7 @@ const buildTime = (defaultTime?: number): Time => {
 }
 
 const reducer = (state: Time, action: TimeAction): Time => {
+  const step = 15
   switch (action.type) {
     case 'hour': {
       let newValue = action.value
@@ -71,14 +72,14 @@ const reducer = (state: Time, action: TimeAction): Time => {
         }
         return { ...state, hour: newValue }
       } else if (action.unit === 'minute') {
-        if (state.minute >= 59) {
+        if (state.minute >= 60 - step) {
           return {
             ...state,
             hour: state.hour >= 23 ? 0 : state.hour + 1,
             minute: 0,
           }
         } else {
-          return { ...state, minute: state.minute + 1 }
+          return { ...state, minute: state.minute + step }
         }
       } else {
         throw new Error(`not implemented action: ${action.unit}`)
@@ -97,10 +98,10 @@ const reducer = (state: Time, action: TimeAction): Time => {
           return {
             ...state,
             hour: state.hour <= 0 ? 23 : state.hour - 1,
-            minute: 59,
+            minute: 60 - step,
           }
         } else {
-          return { ...state, minute: state.minute - 1 }
+          return { ...state, minute: state.minute - step }
         }
       } else {
         throw new Error(`not implemented action: ${action.unit}`)
@@ -114,11 +115,13 @@ const reducer = (state: Time, action: TimeAction): Time => {
 
 type Props = {
   type?: 'input' | 'text'
+  label?: string
   value?: number
-  onChange?: (newTime: number) => void
+  onChange?: (newTime: Time) => void
 }
 const TimeSelector: React.FC<Props> = ({
   type = 'input',
+  label = '',
   value: defaultTime,
   onChange,
 }) => {
@@ -149,17 +152,17 @@ const TimeSelector: React.FC<Props> = ({
   React.useEffect(() => {
     // 初期化時に無駄な保存処理が走らないようにする
     if (mounted.current) {
-      onChange?.(time.hour * 60 + time.minute)
+      onChange?.(time)
     }
     mounted.current = true
-  }, [onChange, time])
+  }, [time])
 
   const display = () => {
     switch (type) {
       case 'text':
         return (
           <Typography onClick={(e) => setAnchor(e.currentTarget)}>
-            {`${time.hour.toString().padStart(2, '0')}:${time.minute
+            {`${label}${time.hour.toString().padStart(2, '0')}:${time.minute
               .toString()
               .padStart(2, '0')}`}
           </Typography>
@@ -168,6 +171,7 @@ const TimeSelector: React.FC<Props> = ({
       case 'input':
         return (
           <TextField
+            label={label}
             placeholder="HH:MM"
             value={`${time.hour.toString().padStart(2, '0')}:${time.minute
               .toString()

--- a/src/components/modules/TimePicker.tsx
+++ b/src/components/modules/TimePicker.tsx
@@ -113,10 +113,15 @@ const reducer = (state: Time, action: TimeAction): Time => {
 }
 
 type Props = {
+  type?: 'input' | 'text'
   value?: number
   onChange?: (newTime: number) => void
 }
-const TimeSelector: React.FC<Props> = ({ onChange, value: defaultTime }) => {
+const TimeSelector: React.FC<Props> = ({
+  type = 'input',
+  value: defaultTime,
+  onChange,
+}) => {
   const [time, setTime] = React.useReducer(reducer, defaultTime, buildTime)
   const [anchor, setAnchor] = React.useState<HTMLElement | null>(null)
   const theme = useTheme()
@@ -149,18 +154,56 @@ const TimeSelector: React.FC<Props> = ({ onChange, value: defaultTime }) => {
     mounted.current = true
   }, [onChange, time])
 
+  const display = () => {
+    switch (type) {
+      case 'text':
+        return (
+          <Typography onClick={(e) => setAnchor(e.currentTarget)}>
+            {`${time.hour.toString().padStart(2, '0')}:${time.minute
+              .toString()
+              .padStart(2, '0')}`}
+          </Typography>
+        )
+
+      case 'input':
+        return (
+          <TextField
+            placeholder="HH:MM"
+            value={`${time.hour.toString().padStart(2, '0')}:${time.minute
+              .toString()
+              .padStart(2, '0')}`}
+            onClick={(e) => setAnchor(e.currentTarget)}
+            size="small"
+            inputProps={{
+              readOnly: true,
+              style: { textAlign: 'center' },
+            }}
+            sx={{ width: '5rem' }}
+          />
+        )
+
+      default:
+        return (
+          <TextField
+            placeholder="HH:MM"
+            value={`${time.hour.toString().padStart(2, '0')}:${time.minute
+              .toString()
+              .padStart(2, '0')}`}
+            onClick={(e) => setAnchor(e.currentTarget)}
+            size="small"
+            inputProps={{
+              readOnly: true,
+              style: { textAlign: 'center' },
+            }}
+            sx={{ width: '5rem' }}
+          />
+        )
+    }
+  }
+
   return (
     <>
-      <TextField
-        placeholder="HH:MM"
-        value={`${time.hour.toString().padStart(2, '0')}:${time.minute
-          .toString()
-          .padStart(2, '0')}`}
-        onClick={(e) => setAnchor(e.currentTarget)}
-        size="small"
-        inputProps={{ readOnly: true, style: { textAlign: 'center' } }}
-        sx={{ width: '5rem' }}
-      />
+      {display()}
       <PaperPopper
         open={Boolean(anchor)}
         onClose={() => setAnchor(null)}

--- a/src/contexts/CurrentPlanProvider.tsx
+++ b/src/contexts/CurrentPlanProvider.tsx
@@ -28,7 +28,10 @@ export type Spot = {
   lng: number
   labels?: Array<SpotLabel>
   memo?: string
-  mode?: TravelMode
+  next?: {
+    id: string
+    mode: TravelMode
+  }
 }
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const isSpot = (obj: any): obj is Spot => {
@@ -46,7 +49,11 @@ export type Route = {
   from: string
   to: string
   mode: TravelMode
-  time?: string | null
+  time?: {
+    text: string
+    value: number
+    unit: dayjs.ManipulateType
+  } | null
 }
 
 export const isSameRoute = (a: Route, b: Route) =>

--- a/src/contexts/CurrentPlanProvider.tsx
+++ b/src/contexts/CurrentPlanProvider.tsx
@@ -58,6 +58,8 @@ export type Belonging = {
 }
 
 export type Schedule = {
+  start: Date
+  end: Date
   spots: Array<Spot>
 }
 

--- a/src/hooks/usePlan.ts
+++ b/src/hooks/usePlan.ts
@@ -37,7 +37,8 @@ const planConverter: FirestoreDataConverter<Plan> = {
       events:
         data.events?.map((event: DocumentData) => ({
           ...event,
-          date: event.date?.toDate(),
+          start: event.start?.toDate(),
+          end: event.end?.toDate(),
         })) || [],
       routes: data.routes || [],
       lodging: data.lodging || undefined,

--- a/src/hooks/useRoutes.tsx
+++ b/src/hooks/useRoutes.tsx
@@ -25,6 +25,9 @@ export const useRoutes = () => {
           console.error('fail to update routes')
         }
       },
+      /**
+       * ルートキャッシュから、スケジュールに含まれていないスポットのルート情報を削除する
+       */
       clean: () => {
         if (planRef.current) {
           const { events, routes } = planRef.current

--- a/src/hooks/useRoutes.tsx
+++ b/src/hooks/useRoutes.tsx
@@ -22,7 +22,22 @@ export const useRoutes = () => {
             ],
           })
         } else {
-          console.error('fail to update waypoints')
+          console.error('fail to update routes')
+        }
+      },
+      clean: () => {
+        if (planRef.current) {
+          const { events, routes } = planRef.current
+          const waypoints = events.map((e) => e.spots).flat()
+          planApi.update({
+            routes: routes.filter(
+              (route) =>
+                waypoints.find((point) => point.id === route.from) &&
+                waypoints.find((point) => point.id === route.to)
+            ),
+          })
+        } else {
+          console.error('fail to update routes')
         }
       },
       remove: (removed: Route) => {
@@ -33,7 +48,7 @@ export const useRoutes = () => {
             ),
           })
         } else {
-          console.error('fail to update waypoints')
+          console.error('fail to update routes')
         }
       },
       get: (conditions: Pick<Route, 'from' | 'to' | 'mode'>) => {

--- a/src/hooks/useTravelPlan.ts
+++ b/src/hooks/useTravelPlan.ts
@@ -58,8 +58,10 @@ export const useTravelPlan = () => {
           // Guest user でも Plan が更新されるように、DB 周りとは隔離して更新する
           if (updatedPlan.events) {
             // Event 更新時にリストが空になった場合削除する
+            // ただし、Events が 0 個にならないようにする
+            // TODO: ユーザーが最小数を決めれるようにする
             updatedPlan.events = updatedPlan.events.filter(
-              (event) => event.spots.length !== 0
+              (event, i) => event.spots.length !== 0 ||  i === 0
             )
           }
           setPlan({ type: 'update', value: updatedPlan })

--- a/src/hooks/useTravelPlan.ts
+++ b/src/hooks/useTravelPlan.ts
@@ -61,7 +61,7 @@ export const useTravelPlan = () => {
             // ただし、Events が 0 個にならないようにする
             // TODO: ユーザーが最小数を決めれるようにする
             updatedPlan.events = updatedPlan.events.filter(
-              (event, i) => event.spots.length !== 0 ||  i === 0
+              (event, i) => event.spots.length !== 0 || i === 0
             )
           }
           setPlan({ type: 'update', value: updatedPlan })

--- a/src/hooks/useWaypoints.ts
+++ b/src/hooks/useWaypoints.ts
@@ -1,4 +1,5 @@
 import * as React from 'react'
+import dayjs from 'dayjs'
 
 import { Plan, Spot } from 'contexts/CurrentPlanProvider'
 import { useTravelPlan } from './useTravelPlan'
@@ -28,7 +29,19 @@ export const useWaypoints = () => {
                     return event
                   }
                 })
-              : [{ spots: [newSpot] }]
+              : [
+                  {
+                    start: dayjs(planRef.current.start)
+                      .hour(9)
+                      .minute(0)
+                      .toDate(),
+                    end: dayjs(planRef.current.start)
+                      .hour(19)
+                      .minute(0)
+                      .toDate(),
+                    spots: [newSpot],
+                  },
+                ]
 
           planApi.update({
             events: newEvents,

--- a/src/pages/new.tsx
+++ b/src/pages/new.tsx
@@ -81,6 +81,8 @@ const PrefectureSelector = () => {
         belongings: [],
         events: [
           {
+            start: dayjs(planDTO.start).hour(9).minute(0).toDate(),
+            end: dayjs(planDTO.start).hour(19).minute(0).toDate(),
             spots: [],
           },
         ],


### PR DESCRIPTION
close #163 

- 各日の開始時刻と終了時刻をスケジュールモデルに組み込んだ
- 開始日はスケジュールヘッダーに入力箇所を設置
- クリックで TimePicker を表示する
  - Time Picker の表示を文字列だけにするようにした
    - TimePicker で TextField を使うとレイアウトが崩れるため
- Start の変更に合わせて、スケジュール内の時刻が更新されるようにした
  - 合わせて、移動時間項目に value と unit を登録するようにした
- 終了時刻は現状使用していない
