### PR TITLE
Feat/174 show home and hotel route

### DIFF
--- a/src/components/layouts/ScheduleListView.tsx
+++ b/src/components/layouts/ScheduleListView.tsx
@@ -85,8 +85,8 @@ const ScheduleListView: React.FC<Props> = ({ openMapView }) => {
       routesApi.add(
         ...legs.map(
           (leg, i): Route => ({
-            from: spots[i].placeId || '',
-            to: spots[i + 1].placeId || '',
+            from: spots[i].id || '',
+            to: spots[i + 1].id || '',
             mode: 'driving',
             time: {
               ...leg.duration,

--- a/src/components/layouts/ScheduleListView.tsx
+++ b/src/components/layouts/ScheduleListView.tsx
@@ -39,8 +39,12 @@ const ScheduleListView: React.FC<Props> = ({ openMapView }) => {
   const confirm = useConfirm()
 
   const [open, setOpen] = React.useState(false)
-  const handleOpen = () => setOpen(true)
-  const handleClose = React.useCallback(() => setOpen(false), [])
+  const handleClick = () => setOpen((prev) => !prev)
+  const handleClose = React.useCallback((_, reason: string) => {
+    if (reason !== 'mouseLeave') {
+      setOpen(false)
+    }
+  }, [])
 
   React.useEffect(() => {
     if (!plan) {
@@ -51,7 +55,7 @@ const ScheduleListView: React.FC<Props> = ({ openMapView }) => {
   const handleAddHotel = React.useCallback(() => {
     openMapView()
     setLayer('selector')
-  }, [setLayer])
+  }, [openMapView, setLayer])
 
   const handleOptimizeRoute = React.useCallback(async () => {
     if (!plan) {
@@ -63,6 +67,7 @@ const ScheduleListView: React.FC<Props> = ({ openMapView }) => {
         description: '現在のスケジュールが上書きされます。よろしいですか?',
         dialogProps: {
           maxWidth: 'sm',
+          disableRestoreFocus: true,
         },
       })
     } catch {
@@ -98,17 +103,13 @@ const ScheduleListView: React.FC<Props> = ({ openMapView }) => {
     } else {
       alert('cannot find roue')
     }
-  }, [plan, waypoints])
+  }, [confirm, directions, plan, routesApi, waypoints, waypointsApi])
 
   const actions = React.useMemo<Array<Action>>(() => {
-    const handleRun = (action: () => void) => () => {
-      handleClose()
-      action()
-    }
     return [
       {
         label: 'ルート最適化',
-        onClick: handleRun(handleOptimizeRoute),
+        onClick: handleOptimizeRoute,
         icon: (
           <SvgIcon>
             <FontAwesomeIcon icon={faRoute} />
@@ -117,7 +118,7 @@ const ScheduleListView: React.FC<Props> = ({ openMapView }) => {
       },
       {
         label: 'ホテルを設定',
-        onClick: handleRun(handleAddHotel),
+        onClick: handleAddHotel,
         icon: (
           <SvgIcon>
             <FontAwesomeIcon icon={faBed} />
@@ -125,7 +126,7 @@ const ScheduleListView: React.FC<Props> = ({ openMapView }) => {
         ),
       },
     ]
-  }, [handleAddHotel, handleClose, handleOptimizeRoute])
+  }, [handleAddHotel, handleOptimizeRoute])
 
   return (
     <>
@@ -135,7 +136,7 @@ const ScheduleListView: React.FC<Props> = ({ openMapView }) => {
       <Backdrop open={open} />
       <SpeedDial
         open={open}
-        onOpen={handleOpen}
+        onClick={handleClick}
         onClose={handleClose}
         ariaLabel="SpeedDial basic example"
         sx={{ position: 'absolute', bottom: 16, right: 16 }}

--- a/src/components/modules/DayColumn.tsx
+++ b/src/components/modules/DayColumn.tsx
@@ -6,7 +6,11 @@ import { Draggable, Droppable } from 'react-beautiful-dnd'
 import DayHeader from './DayHeader'
 import Route from './Route'
 import SpotEventCard from './SpotEventCard'
-import { NextMove, Schedule } from 'contexts/CurrentPlanProvider'
+import {
+  NextMove,
+  RouteGuidanceAvailable,
+  Schedule,
+} from 'contexts/CurrentPlanProvider'
 import DayMenu from './DayMenu'
 import { useTravelPlan } from 'hooks/useTravelPlan'
 import HomeEventCard from './HomeEventCard'
@@ -23,14 +27,29 @@ const DayColumn: React.FC<Props> = ({ day, schedule, first, last }) => {
   const [, waypointsApi] = useWaypoints()
   const [anchor, setAnchor] = React.useState<null | HTMLElement>(null)
 
-  const home = React.useMemo(
-    () => (plan && first ? plan.home : plan?.lodging),
-    [first, plan]
-  )
-  const dest = React.useMemo(
-    () => (plan && last ? plan.home : plan?.lodging),
-    [last, plan]
-  )
+  const home = React.useMemo<RouteGuidanceAvailable | null>(() => {
+    if (plan) {
+      if (first) {
+        return { ...plan.home, next: schedule.dept }
+      } else if (plan.lodging) {
+        return { ...plan.lodging, next: schedule.dept }
+      }
+    }
+
+    return null
+  }, [first, plan, schedule.dept])
+
+  const dest = React.useMemo<RouteGuidanceAvailable | null>(() => {
+    if (plan) {
+      if (last) {
+        return { ...plan.home, next: schedule.dept }
+      } else if (plan.lodging) {
+        return { ...plan.lodging, next: schedule.dept }
+      }
+    }
+
+    return null
+  }, [last, plan, schedule.dept])
 
   const handleRemoveDay = () => {
     planApi.update({

--- a/src/components/modules/DayColumn.tsx
+++ b/src/components/modules/DayColumn.tsx
@@ -9,6 +9,7 @@ import SpotEventCard from './SpotEventCard'
 import { Schedule } from 'contexts/CurrentPlanProvider'
 import DayMenu from './DayMenu'
 import { useTravelPlan } from 'hooks/useTravelPlan'
+import HomeEventCard from './HomeEventCard'
 
 type Props = {
   day: number
@@ -40,6 +41,14 @@ const DayColumn: React.FC<Props> = ({ day, schedule }) => {
             {...provided.droppableProps}>
             <DayHeader day={day + 1} onOpenMenu={handleOpenMenu} />
             <Box>
+              {plan?.home && (
+                <>
+                  <HomeEventCard name={plan.home.name} date={schedule.start} />
+                  <Box py={0.5}>
+                    <Route origin={plan.home} dest={schedule.spots[0]} />
+                  </Box>
+                </>
+              )}
               {schedule.spots.map((spot, index) => (
                 <Draggable key={spot.id} draggableId={spot.id} index={index}>
                   {(provided) => (
@@ -64,6 +73,17 @@ const DayColumn: React.FC<Props> = ({ day, schedule }) => {
                   )}
                 </Draggable>
               ))}
+              {plan?.home && (
+                <>
+                  <Box py={0.5}>
+                    <Route
+                      origin={schedule.spots.slice(-1)[0]}
+                      dest={plan.home}
+                    />
+                  </Box>
+                  <HomeEventCard name={plan.home.name} date={schedule.end} />
+                </>
+              )}
               {provided.placeholder}
             </Box>
           </Stack>

--- a/src/components/modules/DayColumn.tsx
+++ b/src/components/modules/DayColumn.tsx
@@ -93,7 +93,7 @@ const DayColumn: React.FC<Props> = ({ day, schedule, first, last }) => {
     setAnchor(anchor)
   }
 
-  const handleUpdateHome = React.useCallback(
+  const handleUpdateDeparture = React.useCallback(
     (next: NextMove) => {
       if (plan) {
         planApi.update({
@@ -108,14 +108,14 @@ const DayColumn: React.FC<Props> = ({ day, schedule, first, last }) => {
         })
       }
     },
-    [plan, schedule]
+    [plan, planApi, schedule]
   )
 
   const handleUpdateWaypointNext = React.useCallback(
     (next: NextMove, id: string) => {
       waypointsApi.update(id, { next })
     },
-    []
+    [waypointsApi]
   )
 
   return (
@@ -137,7 +137,7 @@ const DayColumn: React.FC<Props> = ({ day, schedule, first, last }) => {
                     <Route
                       origin={home}
                       dest={schedule.spots[0]}
-                      onChange={handleUpdateHome}
+                      onChange={handleUpdateDeparture}
                     />
                   </Box>
                 </>

--- a/src/components/modules/DayColumn.tsx
+++ b/src/components/modules/DayColumn.tsx
@@ -1,0 +1,82 @@
+import * as React from 'react'
+import Box from '@mui/material/Box'
+import Stack from '@mui/material/Stack'
+import { Draggable, Droppable } from 'react-beautiful-dnd'
+
+import DayHeader from './DayHeader'
+import Route from './Route'
+import SpotEventCard from './SpotEventCard'
+import { Schedule } from 'contexts/CurrentPlanProvider'
+import DayMenu from './DayMenu'
+import { useTravelPlan } from 'hooks/useTravelPlan'
+
+type Props = {
+  day: number
+  schedule: Schedule
+}
+const DayColumn: React.FC<Props> = ({ day, schedule }) => {
+  const [plan, planApi] = useTravelPlan()
+  const [anchor, setAnchor] = React.useState<null | HTMLElement>(null)
+
+  const handleRemoveDay = () => {
+    planApi.update({
+      events: plan?.events.filter((_, i) => i !== plan.events.length - 1),
+    })
+  }
+
+  const handleOpenMenu = (anchor: HTMLElement) => {
+    setAnchor(anchor)
+  }
+
+  return (
+    <>
+      <Droppable droppableId={day.toString()} type="ITEM" direction="vertical">
+        {(provided) => (
+          <Stack
+            spacing={1}
+            width="320px"
+            height="100%"
+            ref={provided.innerRef}
+            {...provided.droppableProps}>
+            <DayHeader day={day + 1} onOpenMenu={handleOpenMenu} />
+            <Box>
+              {schedule.spots.map((spot, index) => (
+                <Draggable key={spot.id} draggableId={spot.id} index={index}>
+                  {(provided) => (
+                    <Box
+                      ref={provided.innerRef}
+                      {...provided.dragHandleProps}
+                      {...provided.draggableProps}>
+                      <SpotEventCard
+                        spot={spot}
+                        prevSpots={schedule.spots.slice(0, index)}
+                        dayStart={schedule.start}
+                      />
+                      {index !== schedule.spots.length - 1 && (
+                        <Box py={0.5}>
+                          <Route
+                            origin={spot}
+                            dest={schedule.spots[index + 1]}
+                          />
+                        </Box>
+                      )}
+                    </Box>
+                  )}
+                </Draggable>
+              ))}
+              {provided.placeholder}
+            </Box>
+          </Stack>
+        )}
+      </Droppable>
+      <DayMenu
+        anchorEl={anchor}
+        open={Boolean(anchor)}
+        onClose={() => setAnchor(null)}
+        onDelete={handleRemoveDay}
+      />
+    </>
+  )
+}
+
+export default DayColumn

--- a/src/components/modules/HomeEventCard.tsx
+++ b/src/components/modules/HomeEventCard.tsx
@@ -1,0 +1,36 @@
+import * as React from 'react'
+import Box from '@mui/material/Box'
+import Grid from '@mui/material/Grid'
+import Typography from '@mui/material/Typography'
+import dayjs from 'dayjs'
+
+type Props = {
+  name: string
+  date: Date
+}
+const HomeEventCard: React.FC<Props> = ({ name, date }) => {
+  return (
+    <Box
+      sx={{
+        border: (theme) => `solid ${theme.palette.grey[300]} 1px`,
+        borderRadius: 2,
+      }}>
+      <Box px={1} py={2}>
+        <Grid container spacing={1} alignItems="center">
+          <Grid item xs={3}>
+            <Typography textAlign="center" variant="subtitle1">
+              {dayjs(date).format('HH:mm')}
+            </Typography>
+          </Grid>
+          <Grid item xs={9}>
+            <Typography variant="h6" noWrap>
+              {name}
+            </Typography>
+          </Grid>
+        </Grid>
+      </Box>
+    </Box>
+  )
+}
+
+export default HomeEventCard

--- a/src/components/modules/ListScheduler.tsx
+++ b/src/components/modules/ListScheduler.tsx
@@ -12,13 +12,8 @@ import {
 } from 'react-beautiful-dnd'
 import dayjs from 'dayjs'
 
-import DayHeader from './DayHeader'
-import DayMenu from './DayMenu'
-import Route from './Route'
-import SpotEventCard from './SpotEventCard'
-import SpotEventEditor from './SpotEventEditor'
-import { Spot } from 'contexts/CurrentPlanProvider'
 import { useTravelPlan } from 'hooks/useTravelPlan'
+import DayColumn from './DayColumn'
 
 const reorder = <T,>(list: T[], startIndex: number, endIndex: number): T[] => {
   const result = Array.from(list)
@@ -29,18 +24,6 @@ const reorder = <T,>(list: T[], startIndex: number, endIndex: number): T[] => {
 }
 const ListScheduler: React.FC = () => {
   const [plan, planApi] = useTravelPlan()
-  const [editSpot, setEditSpot] = React.useState<Spot | null>(null)
-  const [anchor, setAnchor] = React.useState<null | HTMLElement>(null)
-
-  const handleRemoveDay = () => {
-    planApi.update({
-      events: plan?.events.filter((_, i) => i !== plan.events.length - 1),
-    })
-  }
-
-  const handleOpenMenu = (anchor: HTMLElement) => {
-    setAnchor(anchor)
-  }
 
   const handleDragEnd = (result: DropResult) => {
     if (!result.destination || !plan) {
@@ -146,59 +129,7 @@ const ListScheduler: React.FC = () => {
                       ref={provided.innerRef}
                       {...provided.dragHandleProps}
                       {...provided.draggableProps}>
-                      <Droppable
-                        droppableId={i.toString()}
-                        type="ITEM"
-                        direction="vertical">
-                        {(provided) => (
-                          <Stack
-                            spacing={1}
-                            width="320px"
-                            height="100%"
-                            ref={provided.innerRef}
-                            {...provided.droppableProps}>
-                            <DayHeader
-                              day={i + 1}
-                              onOpenMenu={handleOpenMenu}
-                            />
-                            <Box>
-                              {event.spots.map((spot, index) => (
-                                <Draggable
-                                  key={spot.id}
-                                  draggableId={spot.id}
-                                  index={index}>
-                                  {(provided) => (
-                                    <Box
-                                      ref={provided.innerRef}
-                                      {...provided.dragHandleProps}
-                                      {...provided.draggableProps}>
-                                      <Box onClick={() => setEditSpot(spot)}>
-                                        <SpotEventCard
-                                          spot={spot}
-                                          prevSpots={event.spots.slice(
-                                            0,
-                                            index
-                                          )}
-                                          dayStart={event.start}
-                                        />
-                                      </Box>
-                                      {index !== event.spots.length - 1 && (
-                                        <Box py={0.5}>
-                                          <Route
-                                            origin={spot}
-                                            dest={event.spots[index + 1]}
-                                          />
-                                        </Box>
-                                      )}
-                                    </Box>
-                                  )}
-                                </Draggable>
-                              ))}
-                              {provided.placeholder}
-                            </Box>
-                          </Stack>
-                        )}
-                      </Droppable>
+                      <DayColumn day={i} schedule={event} />
                     </Box>
                   )}
                 </Draggable>
@@ -224,19 +155,6 @@ const ListScheduler: React.FC = () => {
           )}
         </Droppable>
       </DragDropContext>
-      <DayMenu
-        anchorEl={anchor}
-        open={Boolean(anchor)}
-        onClose={() => setAnchor(null)}
-        onDelete={handleRemoveDay}
-      />
-      {editSpot && (
-        <SpotEventEditor
-          spotId={editSpot.id}
-          open={Boolean(editSpot)}
-          onClose={() => setEditSpot(null)}
-        />
-      )}
     </>
   )
 }

--- a/src/components/modules/ListScheduler.tsx
+++ b/src/components/modules/ListScheduler.tsx
@@ -129,7 +129,12 @@ const ListScheduler: React.FC = () => {
                       ref={provided.innerRef}
                       {...provided.dragHandleProps}
                       {...provided.draggableProps}>
-                      <DayColumn day={i} schedule={event} />
+                      <DayColumn
+                        day={i}
+                        schedule={event}
+                        first={i === 0}
+                        last={i === plan.events.length - 1}
+                      />
                     </Box>
                   )}
                 </Draggable>

--- a/src/components/modules/MapSelectorLayer.tsx
+++ b/src/components/modules/MapSelectorLayer.tsx
@@ -36,13 +36,10 @@ const MapSelectorLayer = () => {
     if (center) {
       planApi.update({
         lodging: {
+          id: 'lodging',
           name: 'Hotel',
           lat: center.lat(),
           lng: center.lng(),
-          placeId: null,
-          imageUrl: '',
-          duration: 30,
-          durationUnit: 'minute',
         },
       })
     } else {

--- a/src/components/modules/PrefectureSelector.tsx
+++ b/src/components/modules/PrefectureSelector.tsx
@@ -37,7 +37,7 @@ const PrefectureSelector: React.FC<Props> = ({ value, label, onChange }) => {
     if (prefecture) {
       onChange?.({
         ...prefecture,
-        placeId: prefecture.place_id,
+        id: prefecture.place_id,
       })
     }
   }
@@ -72,8 +72,7 @@ const PrefectureSelector: React.FC<Props> = ({ value, label, onChange }) => {
           label={label}
           id={`prefecture-selector-${label}`}
           value={
-            data?.prefectures.find((p) => p.place_id === value?.placeId)
-              ?.code || ''
+            data?.prefectures.find((p) => p.place_id === value?.id)?.code || ''
           }
           onChange={handleChange}>
           {loading ? (

--- a/src/components/modules/Route.tsx
+++ b/src/components/modules/Route.tsx
@@ -23,7 +23,7 @@ import {
 } from 'hooks/googlemaps/useDirections'
 import { useRoutes } from 'hooks/useRoutes'
 import { useOpenMap } from 'hooks/googlemaps/useOpenMap'
-import { Spot } from 'contexts/CurrentPlanProvider'
+import { RouteGuidanceAvailable } from 'contexts/CurrentPlanProvider'
 import { useWaypoints } from 'hooks/useWaypoints'
 
 const modes: Record<TravelMode, IconDefinition> = {
@@ -34,8 +34,8 @@ const modes: Record<TravelMode, IconDefinition> = {
 }
 
 type Props = {
-  origin: Spot
-  dest: Spot
+  origin: RouteGuidanceAvailable
+  dest: RouteGuidanceAvailable
 }
 const Route: React.FC<Props> = ({ origin, dest }) => {
   const [selecting, setSelecting] = React.useState(false)

--- a/src/components/modules/Route.tsx
+++ b/src/components/modules/Route.tsx
@@ -23,8 +23,7 @@ import {
 } from 'hooks/googlemaps/useDirections'
 import { useRoutes } from 'hooks/useRoutes'
 import { useOpenMap } from 'hooks/googlemaps/useOpenMap'
-import { RouteGuidanceAvailable } from 'contexts/CurrentPlanProvider'
-import { useWaypoints } from 'hooks/useWaypoints'
+import { NextMove, RouteGuidanceAvailable } from 'contexts/CurrentPlanProvider'
 
 const modes: Record<TravelMode, IconDefinition> = {
   driving: faCar,
@@ -36,15 +35,15 @@ const modes: Record<TravelMode, IconDefinition> = {
 type Props = {
   origin: RouteGuidanceAvailable
   dest: RouteGuidanceAvailable
+  onChange: (next: NextMove, prevId: string) => void
 }
-const Route: React.FC<Props> = ({ origin, dest }) => {
+const Route: React.FC<Props> = ({ origin, dest, onChange }) => {
   const [selecting, setSelecting] = React.useState(false)
   const [selected, setSelected] = React.useState<TravelMode>(
     origin.next?.mode || 'driving'
   )
 
   const routesApi = useRoutes()
-  const [, waypointsApi] = useWaypoints()
   const { search, loading } = useDirections()
   const [time, setTime] = React.useState('')
 
@@ -64,11 +63,9 @@ const Route: React.FC<Props> = ({ origin, dest }) => {
   React.useEffect(() => {
     if (origin.next?.mode !== selected) {
       console.log('update travel mode')
-      waypointsApi.update(origin.id, {
-        next: { id: dest.id, mode: selected },
-      })
+      onChange({ id: dest.id, mode: selected }, origin.id)
     }
-  }, [dest.id, origin.id, origin.next, selected, waypointsApi])
+  }, [dest.id, origin.id, selected])
 
   React.useEffect(() => {
     const routeCache = routesApi.get({

--- a/src/components/modules/Route.tsx
+++ b/src/components/modules/Route.tsx
@@ -61,13 +61,10 @@ const Route: React.FC<Props> = ({ origin, dest, onChange }) => {
   }
 
   React.useEffect(() => {
-    if (origin.next?.mode !== selected) {
-      console.log('update travel mode')
+    if (origin.next?.mode !== selected || origin.next.id !== dest.id) {
       onChange({ id: dest.id, mode: selected }, origin.id)
     }
-  }, [dest.id, origin.id, selected])
 
-  React.useEffect(() => {
     const routeCache = routesApi.get({
       from: origin.id,
       to: dest.id,
@@ -92,6 +89,7 @@ const Route: React.FC<Props> = ({ origin, dest, onChange }) => {
         })
       })
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [origin.id, dest.id, selected])
 
   return (

--- a/src/components/modules/SelectPrefectureDialog.tsx
+++ b/src/components/modules/SelectPrefectureDialog.tsx
@@ -28,7 +28,7 @@ const SelectPrefectureDialog: React.FC<Props> = ({ open, onOK, onClose }) => {
     if (prefecture) {
       onOK?.({
         ...prefecture,
-        placeId: prefecture.place_id,
+        id: prefecture.place_id,
       })
     }
   }

--- a/src/components/modules/SpotEventCard.tsx
+++ b/src/components/modules/SpotEventCard.tsx
@@ -6,37 +6,15 @@ import Stack from '@mui/material/Stack'
 import Typography from '@mui/material/Typography'
 
 import { Spot } from 'contexts/CurrentPlanProvider'
-import dayjs from 'dayjs'
-import { useRoutes } from 'hooks/useRoutes'
 import { useSpotEditor } from 'contexts/SpotEditorProvider'
+import dayjs from 'dayjs'
 
 type Props = {
   spot: Spot
-  prevSpots: Array<Spot>
-  dayStart: Date
+  start: Date
 }
-const SpotEventCard: React.FC<Props> = ({ spot, prevSpots, dayStart }) => {
+const SpotEventCard: React.FC<Props> = ({ spot, start }) => {
   const { open } = useSpotEditor()
-  const routesApi = useRoutes()
-
-  const start = () => {
-    let _start = dayjs(dayStart)
-    prevSpots.forEach((prev) => {
-      // このスポットよりも前にスケジュールされているスポットの滞在時間と移動時間を加算
-      const nextRoute =
-        prev.next &&
-        routesApi.get({
-          from: prev.id,
-          to: prev.next.id,
-          mode: prev.next.mode,
-        })
-      _start = dayjs(_start)
-        .add(prev.duration, prev.durationUnit)
-        .add(nextRoute?.time?.value || 0, nextRoute?.time?.unit)
-    })
-
-    return _start
-  }
 
   return (
     <Box
@@ -53,7 +31,7 @@ const SpotEventCard: React.FC<Props> = ({ spot, prevSpots, dayStart }) => {
               alignItems="center"
               height="100%">
               <Typography variant="subtitle1">
-                {start().format('HH:mm')}
+                {dayjs(start).format('HH:mm')}
               </Typography>
               <Box
                 flexGrow={1}
@@ -64,7 +42,9 @@ const SpotEventCard: React.FC<Props> = ({ spot, prevSpots, dayStart }) => {
                 }}
               />
               <Typography variant="subtitle1">
-                {start().add(spot.duration, spot.durationUnit).format('HH:mm')}
+                {dayjs(start)
+                  .add(spot.duration, spot.durationUnit)
+                  .format('HH:mm')}
               </Typography>
             </Stack>
           </Grid>

--- a/src/components/modules/SpotEventCard.tsx
+++ b/src/components/modules/SpotEventCard.tsx
@@ -8,6 +8,7 @@ import Typography from '@mui/material/Typography'
 import { Spot } from 'contexts/CurrentPlanProvider'
 import dayjs from 'dayjs'
 import { useRoutes } from 'hooks/useRoutes'
+import { useSpotEditor } from 'contexts/SpotEditorProvider'
 
 type Props = {
   spot: Spot
@@ -15,7 +16,9 @@ type Props = {
   dayStart: Date
 }
 const SpotEventCard: React.FC<Props> = ({ spot, prevSpots, dayStart }) => {
+  const { open } = useSpotEditor()
   const routesApi = useRoutes()
+
   const start = () => {
     let _start = dayjs(dayStart)
     prevSpots.forEach((prev) => {
@@ -37,6 +40,7 @@ const SpotEventCard: React.FC<Props> = ({ spot, prevSpots, dayStart }) => {
 
   return (
     <Box
+      onClick={() => open(spot)}
       sx={{
         border: (theme) => `solid ${theme.palette.grey[300]} 1px`,
         borderRadius: 2,

--- a/src/contexts/CurrentPlanProvider.tsx
+++ b/src/contexts/CurrentPlanProvider.tsx
@@ -10,14 +10,14 @@ export type NextMove = {
   mode: TravelMode
 }
 
-export type RouteGuidanceAvailable = {
+export type SpotBase = {
   id: string
   lat: number
   lng: number
-  next?: NextMove
-}
-type SpotBase = RouteGuidanceAvailable & {
   name: string
+}
+export type RouteGuidanceAvailable = SpotBase & {
+  next?: NextMove
 }
 
 export type Prefecture = SpotBase & {
@@ -29,7 +29,7 @@ export type Prefecture = SpotBase & {
 
 export type SpotLabel = string
 
-export type Spot = SpotBase & {
+export type Spot = RouteGuidanceAvailable & {
   imageUrl: string
   placeId?: string | null
   duration: number

--- a/src/contexts/CurrentPlanProvider.tsx
+++ b/src/contexts/CurrentPlanProvider.tsx
@@ -5,7 +5,7 @@ import { useAuthentication } from 'hooks/firebase/useAuthentication'
 import { usePlans } from 'hooks/usePlan'
 import { TravelMode } from 'hooks/googlemaps/useDirections'
 
-type NextMove = {
+export type NextMove = {
   id: string
   mode: TravelMode
 }
@@ -16,7 +16,11 @@ export type RouteGuidanceAvailable = {
   lng: number
   next?: NextMove
 }
-export type Prefecture = RouteGuidanceAvailable & {
+type SpotBase = RouteGuidanceAvailable & {
+  name: string
+}
+
+export type Prefecture = SpotBase & {
   name: string
   name_en: string
   zoom: number
@@ -25,10 +29,9 @@ export type Prefecture = RouteGuidanceAvailable & {
 
 export type SpotLabel = string
 
-export type Spot = RouteGuidanceAvailable & {
+export type Spot = SpotBase & {
   imageUrl: string
   placeId?: string | null
-  name: string
   duration: number
   durationUnit: dayjs.ManipulateType
   labels?: Array<SpotLabel>
@@ -69,6 +72,7 @@ export type Belonging = {
 export type Schedule = {
   start: Date
   end: Date
+  dept?: NextMove
   spots: Array<Spot>
 }
 
@@ -82,7 +86,7 @@ export type Plan = {
   end: Date
   events: Array<Schedule>
   routes: Array<Route>
-  lodging?: Omit<Spot, 'id'>
+  lodging?: SpotBase
   belongings: Array<Belonging>
   /**
    * 宿泊日数、未定なら null

--- a/src/contexts/CurrentPlanProvider.tsx
+++ b/src/contexts/CurrentPlanProvider.tsx
@@ -5,34 +5,36 @@ import { useAuthentication } from 'hooks/firebase/useAuthentication'
 import { usePlans } from 'hooks/usePlan'
 import { TravelMode } from 'hooks/googlemaps/useDirections'
 
-export type Prefecture = {
-  name: string
-  name_en: string
+type NextMove = {
+  id: string
+  mode: TravelMode
+}
+
+export type RouteGuidanceAvailable = {
+  id: string
   lat: number
   lng: number
+  next?: NextMove
+}
+export type Prefecture = RouteGuidanceAvailable & {
+  name: string
+  name_en: string
   zoom: number
-  placeId: string
   imageUrl: string
 }
 
 export type SpotLabel = string
 
-export type Spot = {
-  id: string
+export type Spot = RouteGuidanceAvailable & {
   imageUrl: string
   placeId?: string | null
   name: string
   duration: number
   durationUnit: dayjs.ManipulateType
-  lat: number
-  lng: number
   labels?: Array<SpotLabel>
   memo?: string
-  next?: {
-    id: string
-    mode: TravelMode
-  }
 }
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const isSpot = (obj: any): obj is Spot => {
   return (

--- a/src/contexts/SpotEditorProvider.tsx
+++ b/src/contexts/SpotEditorProvider.tsx
@@ -1,0 +1,43 @@
+import SpotEventEditor from 'components/modules/SpotEventEditor'
+import * as React from 'react'
+import { Spot } from './CurrentPlanProvider'
+
+const SpotEditorContext = React.createContext<
+  React.Dispatch<React.SetStateAction<Spot | null>>
+>(() => {
+  throw Error('SpotEditorProvider is not wrapped')
+})
+
+export const SpotEditorProvider: React.FC = ({ children }) => {
+  const [spot, setSpot] = React.useState<Spot | null>(null)
+
+  return (
+    <>
+      <SpotEditorContext.Provider value={setSpot}>
+        {children}
+      </SpotEditorContext.Provider>
+      {spot && (
+        <SpotEventEditor
+          open={Boolean(spot)}
+          onClose={() => setSpot(null)}
+          spotId={spot.id}
+        />
+      )}
+    </>
+  )
+}
+
+export const useSpotEditor = () => {
+  const setSpot = React.useContext(SpotEditorContext)
+
+  const actions = React.useMemo(() => {
+    const a = {
+      open: (target: Spot) => setSpot(target),
+      close: () => setSpot(null),
+    }
+
+    return a
+  }, [setSpot])
+
+  return actions
+}

--- a/src/hooks/useRoutes.tsx
+++ b/src/hooks/useRoutes.tsx
@@ -1,6 +1,11 @@
 import * as React from 'react'
 
-import { Plan, Route, isSameRoute } from 'contexts/CurrentPlanProvider'
+import {
+  Plan,
+  Route,
+  isSameRoute,
+  SpotBase,
+} from 'contexts/CurrentPlanProvider'
 import { useTravelPlan } from './useTravelPlan'
 
 export const useRoutes = () => {
@@ -34,7 +39,15 @@ export const useRoutes = () => {
       clean: () => {
         if (planRef.current) {
           const { events, routes } = planRef.current
-          const waypoints = events.map((e) => e.spots).flat()
+          const waypoints = events
+            .map((e): Array<SpotBase> => e.spots)
+            .flat()
+            .concat(
+              [planRef.current.home, planRef.current.lodging].filter(
+                (spot): spot is SpotBase => spot !== undefined
+              )
+            )
+
           planApi.update({
             routes: routes.filter(
               (route) =>

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -17,6 +17,7 @@ import { ConfirmationProvider } from 'contexts/ConfirmationProvider'
 import { MapPropsProvider } from 'contexts/MapPropsProvider'
 import { SelectedSpotsProvider } from 'contexts/SelectedSpotsProvider'
 import UserAuthorizationProvider from 'contexts/UserAuthorizationProvider'
+import { SpotEditorProvider } from 'contexts/SpotEditorProvider'
 
 const clientSideEmotionCache = createEmotionCache()
 interface MyAppProps extends AppProps {
@@ -42,10 +43,12 @@ const App: React.FC<MyAppProps> = ({
                   <PlacesServiceProvider>
                     <CurrentPlanContextProvider>
                       <SelectedSpotsProvider>
-                        <ThemeProvider theme={theme}>
-                          <CssBaseline />
-                          <Component {...pageProps} />
-                        </ThemeProvider>
+                        <SpotEditorProvider>
+                          <ThemeProvider theme={theme}>
+                            <CssBaseline />
+                            <Component {...pageProps} />
+                          </ThemeProvider>
+                        </SpotEditorProvider>
                       </SelectedSpotsProvider>
                     </CurrentPlanContextProvider>
                   </PlacesServiceProvider>


### PR DESCRIPTION
close #174 

- スケジュールのはじめと終わりにホーム、及びホテルを表示するようにした
- 初日の始まりと最終日の終わりはホーム、それ以外はホテルを表示
- 始まりからの移動をキャッシュするための変更を行った
  - ルートキャッシュクリア時に、ホームとホテルのidを候補に追加
  - スケジュールモデルに移動情報を参照するための departure プロパティを追加