### PR TITLE
Feat/178 leads add hotel

### DIFF
--- a/src/components/layouts/PlanLayout.tsx
+++ b/src/components/layouts/PlanLayout.tsx
@@ -5,6 +5,7 @@ import Link from 'next/link'
 
 import Layout from './Layout'
 import PlanningLayout from 'components/layouts/PlaningLayout'
+import { PlanningTabProvider } from 'contexts/PlannigTabProvider'
 import { useTravelPlan } from 'hooks/useTravelPlan'
 import { useRouter } from 'hooks/useRouter'
 
@@ -24,9 +25,11 @@ const PlanLayout = () => {
   }
 
   return (
-    <Layout title={plan.title} fixedHeader>
-      <PlanningLayout />
-    </Layout>
+    <PlanningTabProvider>
+      <Layout title={plan.title} fixedHeader>
+        <PlanningLayout />
+      </Layout>
+    </PlanningTabProvider>
   )
 }
 

--- a/src/components/layouts/PlaningLayout.tsx
+++ b/src/components/layouts/PlaningLayout.tsx
@@ -18,7 +18,6 @@ import Div100vh from 'react-div-100vh'
 import MapView from './MapView'
 import PlanView from './PlanView'
 import TabPanel from 'components/modules/TabPanel'
-import { MapLayerProvider } from 'contexts/MapLayerModeProvider'
 import ScheduleListView from './ScheduleListView'
 import { useRoutes } from 'hooks/useRoutes'
 import { PlanningTab, usePlanningTab } from 'contexts/PlannigTabProvider'
@@ -60,33 +59,31 @@ const PlanningLayout: React.FC = () => {
             position: 'relative',
             flex: '1 1 0%',
           }}>
-          <MapLayerProvider>
-            <TabPanel
-              value={tab}
-              index={'info'}
-              position="absolute"
-              overflow="hidden auto">
-              <Box maxWidth="sm" mx="auto">
-                <PlanView />
-              </Box>
-            </TabPanel>
-            <TabPanel
-              value={tab}
-              index={'map'}
-              position="absolute"
-              overflow="hidden auto">
-              <MapView />
-            </TabPanel>
-            <TabPanel
-              value={tab}
-              index={'schedule'}
-              position="absolute"
-              overflow="hidden auto">
-              <Container sx={{ height: '100%', overflow: 'hidden' }}>
-                <ScheduleListView openMapView={tabSwitch.openMap} />
-              </Container>
-            </TabPanel>
-          </MapLayerProvider>
+          <TabPanel
+            value={tab}
+            index={'info'}
+            position="absolute"
+            overflow="hidden auto">
+            <Box maxWidth="sm" mx="auto">
+              <PlanView />
+            </Box>
+          </TabPanel>
+          <TabPanel
+            value={tab}
+            index={'map'}
+            position="absolute"
+            overflow="hidden auto">
+            <MapView />
+          </TabPanel>
+          <TabPanel
+            value={tab}
+            index={'schedule'}
+            position="absolute"
+            overflow="hidden auto">
+            <Container sx={{ height: '100%', overflow: 'hidden' }}>
+              <ScheduleListView />
+            </Container>
+          </TabPanel>
         </Box>
         <Tabs value={tab} variant="fullWidth" onChange={handleChange}>
           <MyTab

--- a/src/components/layouts/PlaningLayout.tsx
+++ b/src/components/layouts/PlaningLayout.tsx
@@ -21,6 +21,7 @@ import TabPanel from 'components/modules/TabPanel'
 import { MapLayerProvider } from 'contexts/MapLayerModeProvider'
 import ScheduleListView from './ScheduleListView'
 import { useRoutes } from 'hooks/useRoutes'
+import { PlanningTab, usePlanningTab } from 'contexts/PlannigTabProvider'
 
 const MyTab = styled(Tab)`
   padding: 0;
@@ -28,8 +29,8 @@ const MyTab = styled(Tab)`
 `
 
 const PlanningLayout: React.FC = () => {
-  const [value, setValue] = React.useState(1)
   const routesApi = useRoutes()
+  const [tab, tabSwitch] = usePlanningTab()
 
   React.useEffect(() => {
     // とりあえずページアクセス時にキャッシュを削除するようにする
@@ -38,8 +39,8 @@ const PlanningLayout: React.FC = () => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
-  const handleChange = (event: React.SyntheticEvent, newValue: number) => {
-    setValue(newValue)
+  const handleChange = (event: React.SyntheticEvent, newValue: PlanningTab) => {
+    tabSwitch.open(newValue)
   }
 
   return (
@@ -61,8 +62,8 @@ const PlanningLayout: React.FC = () => {
           }}>
           <MapLayerProvider>
             <TabPanel
-              value={value}
-              index={0}
+              value={tab}
+              index={'info'}
               position="absolute"
               overflow="hidden auto">
               <Box maxWidth="sm" mx="auto">
@@ -70,25 +71,26 @@ const PlanningLayout: React.FC = () => {
               </Box>
             </TabPanel>
             <TabPanel
-              value={value}
-              index={1}
+              value={tab}
+              index={'map'}
               position="absolute"
               overflow="hidden auto">
               <MapView />
             </TabPanel>
             <TabPanel
-              value={value}
-              index={2}
+              value={tab}
+              index={'schedule'}
               position="absolute"
               overflow="hidden auto">
               <Container sx={{ height: '100%', overflow: 'hidden' }}>
-                <ScheduleListView openMapView={() => setValue(1)} />
+                <ScheduleListView openMapView={tabSwitch.openMap} />
               </Container>
             </TabPanel>
           </MapLayerProvider>
         </Box>
-        <Tabs value={value} variant="fullWidth" onChange={handleChange}>
+        <Tabs value={tab} variant="fullWidth" onChange={handleChange}>
           <MyTab
+            value="info"
             icon={
               <SvgIcon>
                 <FontAwesomeIcon icon={faSuitcase} />
@@ -97,6 +99,7 @@ const PlanningLayout: React.FC = () => {
             label={<Typography variant="caption">プラン情報</Typography>}
           />
           <MyTab
+            value="map"
             icon={
               <SvgIcon>
                 <FontAwesomeIcon icon={faMapLocationDot} />
@@ -105,6 +108,7 @@ const PlanningLayout: React.FC = () => {
             label={<Typography variant="caption">マップ</Typography>}
           />
           <MyTab
+            value="schedule"
             icon={
               <SvgIcon>
                 <FontAwesomeIcon icon={faCalendarWeek} />

--- a/src/components/layouts/ScheduleListView.tsx
+++ b/src/components/layouts/ScheduleListView.tsx
@@ -17,8 +17,8 @@ import { useWaypoints } from 'hooks/useWaypoints'
 import { useDirections } from 'hooks/googlemaps/useDirections'
 import { useRoutes } from 'hooks/useRoutes'
 import type { Route } from 'contexts/CurrentPlanProvider'
-import { useMapLayer } from 'contexts/MapLayerModeProvider'
 import { useConfirm } from 'hooks/useConfirm'
+import { usePlanningTab } from 'contexts/PlannigTabProvider'
 
 type Action = {
   label: string
@@ -26,17 +26,14 @@ type Action = {
   onClick: (e: React.MouseEvent<HTMLDivElement, MouseEvent>) => void
 }
 
-type Props = {
-  openMapView: () => void
-}
-const ScheduleListView: React.FC<Props> = ({ openMapView }) => {
+const ScheduleListView: React.FC = () => {
   const router = useRouter()
   const [plan] = useTravelPlan()
   const [waypoints, waypointsApi] = useWaypoints()
   const routesApi = useRoutes()
   const directions = useDirections()
-  const [, setLayer] = useMapLayer()
   const confirm = useConfirm()
+  const [, { openMap }] = usePlanningTab()
 
   const [open, setOpen] = React.useState(false)
   const handleClick = () => setOpen((prev) => !prev)
@@ -53,9 +50,8 @@ const ScheduleListView: React.FC<Props> = ({ openMapView }) => {
   }, [plan, router])
 
   const handleAddHotel = React.useCallback(() => {
-    openMapView()
-    setLayer('selector')
-  }, [openMapView, setLayer])
+    openMap('selector')
+  }, [openMap])
 
   const handleOptimizeRoute = React.useCallback(async () => {
     if (!plan) {

--- a/src/components/modules/AddEventCard.tsx
+++ b/src/components/modules/AddEventCard.tsx
@@ -5,7 +5,7 @@ import Typography from '@mui/material/Typography'
 
 type Props = {
   text: string
-  onClick: () => void
+  onClick: (e?: React.MouseEvent) => void
 }
 const AddEventCard: React.FC<Props> = ({ text, onClick }) => {
   return (

--- a/src/components/modules/AddEventCard.tsx
+++ b/src/components/modules/AddEventCard.tsx
@@ -1,0 +1,29 @@
+import * as React from 'react'
+import Box from '@mui/material/Box'
+import Button from '@mui/material/Button'
+import Typography from '@mui/material/Typography'
+
+type Props = {
+  text: string
+  onClick: () => void
+}
+const AddEventCard: React.FC<Props> = ({ text, onClick }) => {
+  return (
+    <Box
+      fullWidth
+      color="black"
+      component={Button}
+      onClick={onClick}
+      sx={{
+        aspectRatio: '4/1',
+        border: (theme) => `dashed ${theme.palette.grey[300]} 2px`,
+        borderRadius: 2,
+      }}>
+      <Typography textAlign="center" variant="h6">
+        {text}
+      </Typography>
+    </Box>
+  )
+}
+
+export default AddEventCard

--- a/src/components/modules/DayColumn.tsx
+++ b/src/components/modules/DayColumn.tsx
@@ -31,7 +31,7 @@ const DayColumn: React.FC<Props> = ({ day, schedule, first, last }) => {
   const [plan, planApi] = useTravelPlan()
   const [, waypointsApi] = useWaypoints()
   const [anchor, setAnchor] = React.useState<null | HTMLElement>(null)
-  const [, tabSwitch] = usePlanningTab()
+  const [, { openMap }] = usePlanningTab()
 
   const home = React.useMemo<RouteGuidanceAvailable | null>(() => {
     if (plan) {
@@ -191,7 +191,7 @@ const DayColumn: React.FC<Props> = ({ day, schedule, first, last }) => {
                 <Box pt={4}>
                   <AddEventCard
                     text="ホテルを設定する"
-                    onClick={tabSwitch.openMap}
+                    onClick={() => openMap('selector')}
                   />
                 </Box>
               )}

--- a/src/components/modules/DayColumn.tsx
+++ b/src/components/modules/DayColumn.tsx
@@ -19,6 +19,7 @@ import { useWaypoints } from 'hooks/useWaypoints'
 import { useRoutes } from 'hooks/useRoutes'
 import dayjs from 'dayjs'
 import AddEventCard from './AddEventCard'
+import { usePlanningTab } from 'contexts/PlannigTabProvider'
 
 type Props = {
   day: number
@@ -30,6 +31,7 @@ const DayColumn: React.FC<Props> = ({ day, schedule, first, last }) => {
   const [plan, planApi] = useTravelPlan()
   const [, waypointsApi] = useWaypoints()
   const [anchor, setAnchor] = React.useState<null | HTMLElement>(null)
+  const [, tabSwitch] = usePlanningTab()
 
   const home = React.useMemo<RouteGuidanceAvailable | null>(() => {
     if (plan) {
@@ -187,7 +189,10 @@ const DayColumn: React.FC<Props> = ({ day, schedule, first, last }) => {
                 </>
               ) : (
                 <Box pt={4}>
-                  <AddEventCard text="ホテルを設定する" onClick={() => null} />
+                  <AddEventCard
+                    text="ホテルを設定する"
+                    onClick={tabSwitch.openMap}
+                  />
                 </Box>
               )}
               {provided.placeholder}

--- a/src/components/modules/DayColumn.tsx
+++ b/src/components/modules/DayColumn.tsx
@@ -18,6 +18,7 @@ import HomeEventCard from './HomeEventCard'
 import { useWaypoints } from 'hooks/useWaypoints'
 import { useRoutes } from 'hooks/useRoutes'
 import dayjs from 'dayjs'
+import AddEventCard from './AddEventCard'
 
 type Props = {
   day: number
@@ -48,6 +49,8 @@ const DayColumn: React.FC<Props> = ({ day, schedule, first, last }) => {
         return { ...plan.home, next: schedule.dept }
       } else if (plan.lodging) {
         return { ...plan.lodging, next: schedule.dept }
+      } else {
+        return null
       }
     }
 
@@ -168,7 +171,7 @@ const DayColumn: React.FC<Props> = ({ day, schedule, first, last }) => {
                   )}
                 </Draggable>
               ))}
-              {dest && (
+              {dest ? (
                 <>
                   <Box py={0.5}>
                     <Route
@@ -182,6 +185,10 @@ const DayColumn: React.FC<Props> = ({ day, schedule, first, last }) => {
                     date={summarizeTotalTime(schedule.spots)}
                   />
                 </>
+              ) : (
+                <Box pt={4}>
+                  <AddEventCard text="ホテルを設定する" onClick={() => null} />
+                </Box>
               )}
               {provided.placeholder}
             </Box>

--- a/src/components/modules/ListScheduler.tsx
+++ b/src/components/modules/ListScheduler.tsx
@@ -122,23 +122,29 @@ const ListScheduler: React.FC = () => {
                   display: 'none',
                 },
               }}>
-              {plan?.events.map((event, i) => (
-                <Draggable key={`day-${i}`} draggableId={`day-${i}`} index={i}>
-                  {(provided: DraggableProvided) => (
-                    <Box
-                      ref={provided.innerRef}
-                      {...provided.dragHandleProps}
-                      {...provided.draggableProps}>
-                      <DayColumn
-                        day={i}
-                        schedule={event}
-                        first={i === 0}
-                        last={i === plan.events.length - 1}
-                      />
-                    </Box>
-                  )}
-                </Draggable>
-              ))}
+              {plan?.events.map(
+                (event, i) =>
+                  event.spots.length > 0 && (
+                    <Draggable
+                      key={`day-${i}`}
+                      draggableId={`day-${i}`}
+                      index={i}>
+                      {(provided: DraggableProvided) => (
+                        <Box
+                          ref={provided.innerRef}
+                          {...provided.dragHandleProps}
+                          {...provided.draggableProps}>
+                          <DayColumn
+                            day={i}
+                            schedule={event}
+                            first={i === 0}
+                            last={i === plan.events.length - 1}
+                          />
+                        </Box>
+                      )}
+                    </Draggable>
+                  )
+              )}
               <Droppable droppableId="newDay" type="ITEM">
                 {(provided) => (
                   <Stack

--- a/src/components/modules/PlanMenu.tsx
+++ b/src/components/modules/PlanMenu.tsx
@@ -8,16 +8,14 @@ import MenuItem from '@mui/material/MenuItem'
 import { useConfirm } from 'hooks/useConfirm'
 import { useTravelPlan } from 'hooks/useTravelPlan'
 import { useAsyncFn } from 'react-use'
-import { useMapLayer } from 'contexts/MapLayerModeProvider'
 import { useRouter } from 'hooks/useRouter'
+import { usePlanningTab } from 'contexts/PlannigTabProvider'
 
-type Props = MenuProps & {
-  addHotelCallback?: () => void
-}
-const PlanMenu: React.FC<Props> = ({ addHotelCallback, ...props }) => {
+type Props = MenuProps
+const PlanMenu: React.FC<Props> = (props) => {
   const [, planApi] = useTravelPlan()
+  const [, { openMap }] = usePlanningTab()
   const confirm = useConfirm()
-  const [, setMode] = useMapLayer()
   const router = useRouter()
 
   const [{ loading }, handleOptimize] = useAsyncFn(async () => {
@@ -40,9 +38,8 @@ const PlanMenu: React.FC<Props> = ({ addHotelCallback, ...props }) => {
   }, [confirm, planApi])
 
   const handleAddHotel = () => {
-    setMode('selector')
+    openMap('selector')
     props.onClose?.({}, 'backdropClick')
-    addHotelCallback?.()
   }
 
   const handleDelete = async () => {

--- a/src/components/modules/PrefectureSelector.tsx
+++ b/src/components/modules/PrefectureSelector.tsx
@@ -23,7 +23,7 @@ const PrefectureSelector: React.FC<Props> = ({ value, label, onChange }) => {
   const [openDialog, setOpenDialog] = React.useState<DialogProps>({
     open: false,
   })
-  const { data, loading, error } = useGetPrefecturesQuery()
+  const { data, error } = useGetPrefecturesQuery()
 
   const handleChange = (event: SelectChangeEvent<number | string>) => {
     if (!data) {
@@ -75,15 +75,11 @@ const PrefectureSelector: React.FC<Props> = ({ value, label, onChange }) => {
             data?.prefectures.find((p) => p.place_id === value?.id)?.code || ''
           }
           onChange={handleChange}>
-          {loading ? (
-            <>loading</>
-          ) : (
-            data?.prefectures.map((prefecture) => (
-              <MenuItem key={prefecture.code} value={prefecture.code}>
-                {prefecture.name}
-              </MenuItem>
-            ))
-          )}
+          {data?.prefectures.map((prefecture) => (
+            <MenuItem key={prefecture.code} value={prefecture.code}>
+              {prefecture.name}
+            </MenuItem>
+          ))}
         </Select>
       </FormControl>
       <IconButton color="primary" onClick={handleClick}>

--- a/src/components/modules/SchedulerHeader.tsx
+++ b/src/components/modules/SchedulerHeader.tsx
@@ -14,10 +14,9 @@ import PlanMenu from './PlanMenu'
 
 type Props = {
   plan: Plan
-  addHotel: () => void
   updateTitle: (newTitle: string) => void
 }
-const SchedulerHeader: React.FC<Props> = ({ plan, addHotel, updateTitle }) => {
+const SchedulerHeader: React.FC<Props> = ({ plan, updateTitle }) => {
   const [editTitle, setEditTitle] = React.useState(false)
   const { register, handleSubmit } = useForm<{ title: string }>()
   const [menuAnchor, setMenuAnchor] = React.useState<null | HTMLElement>(null)
@@ -64,7 +63,6 @@ const SchedulerHeader: React.FC<Props> = ({ plan, addHotel, updateTitle }) => {
         anchorEl={menuAnchor}
         open={Boolean(menuAnchor)}
         onClose={() => setMenuAnchor(null)}
-        addHotelCallback={addHotel}
       />
     </>
   )

--- a/src/components/modules/TabPanel.tsx
+++ b/src/components/modules/TabPanel.tsx
@@ -1,12 +1,12 @@
 import * as React from 'react'
 import Box, { BoxProps } from '@mui/material/Box'
-import { PlanningTab } from 'contexts/PlannigTabProvider'
 
-type Props = BoxProps & {
-  index: PlanningTab
-  value: PlanningTab
+type Props<T> = BoxProps & {
+  index: T
+  value: T
 }
-const TabPanel: React.FC<Props> = ({ children, value, index, ...props }) => {
+const TabPanel = <T,>(props: Props<T>) => {
+  const { index, value, children, ...boxProps } = props
   return (
     <Box
       width="100%"
@@ -15,7 +15,7 @@ const TabPanel: React.FC<Props> = ({ children, value, index, ...props }) => {
       hidden={value !== index}
       id={`full-width-tabpanel-${index}`}
       aria-labelledby={`full-width-tab-${index}`}
-      {...props}>
+      {...boxProps}>
       {value === index && children}
     </Box>
   )

--- a/src/components/modules/TabPanel.tsx
+++ b/src/components/modules/TabPanel.tsx
@@ -1,9 +1,10 @@
 import * as React from 'react'
 import Box, { BoxProps } from '@mui/material/Box'
+import { PlanningTab } from 'contexts/PlannigTabProvider'
 
 type Props = BoxProps & {
-  index: number
-  value: number
+  index: PlanningTab
+  value: PlanningTab
 }
 const TabPanel: React.FC<Props> = ({ children, value, index, ...props }) => {
   return (

--- a/src/contexts/MapLayerModeProvider.tsx
+++ b/src/contexts/MapLayerModeProvider.tsx
@@ -2,7 +2,7 @@ import * as React from 'react'
 import MapOverlay from 'components/modules/MapOverlay'
 import MapSelectorLayer from 'components/modules/MapSelectorLayer'
 
-type LayerMode = 'normal' | 'selector'
+export type LayerMode = 'normal' | 'selector'
 const MapLayerModeContext = React.createContext<LayerMode | null>(null)
 const SetMapLayerModeContext = React.createContext<
   React.Dispatch<React.SetStateAction<LayerMode>>

--- a/src/contexts/PlannigTabProvider.tsx
+++ b/src/contexts/PlannigTabProvider.tsx
@@ -1,5 +1,11 @@
 import * as React from 'react'
 
+import {
+  LayerMode,
+  MapLayerProvider,
+  useMapLayer,
+} from 'contexts/MapLayerModeProvider'
+
 export type PlanningTab = 'info' | 'map' | 'schedule'
 const PlanningTabContext = React.createContext<PlanningTab | null>(null)
 const SetPlanningTabContext = React.createContext<
@@ -13,7 +19,7 @@ export const PlanningTabProvider: React.FC = ({ children }) => {
   return (
     <PlanningTabContext.Provider value={tab}>
       <SetPlanningTabContext.Provider value={setTab}>
-        {children}
+        <MapLayerProvider>{children}</MapLayerProvider>
       </SetPlanningTabContext.Provider>
     </PlanningTabContext.Provider>
   )
@@ -27,16 +33,20 @@ export const usePlanningTab = () => {
     throw Error('PlanningTab is not wrapped')
   }
 
+  const [, setLayer] = useMapLayer()
   const actions = React.useMemo(() => {
     const a = {
       open: (value: PlanningTab) => setTab(value),
       openInfo: () => setTab('info'),
-      openMap: () => setTab('map'),
+      openMap: (layer: LayerMode = 'normal') => {
+        setTab('map')
+        setLayer(layer)
+      },
       openSchedule: () => setTab('schedule'),
     }
 
     return a
-  }, [setTab])
+  }, [setLayer, setTab])
 
   return [tab, actions] as const
 }

--- a/src/contexts/PlannigTabProvider.tsx
+++ b/src/contexts/PlannigTabProvider.tsx
@@ -1,0 +1,42 @@
+import * as React from 'react'
+
+export type PlanningTab = 'info' | 'map' | 'schedule'
+const PlanningTabContext = React.createContext<PlanningTab | null>(null)
+const SetPlanningTabContext = React.createContext<
+  React.Dispatch<React.SetStateAction<PlanningTab>>
+>(() => {
+  throw Error('PlanningTabProvider is not wrapped')
+})
+
+export const PlanningTabProvider: React.FC = ({ children }) => {
+  const [tab, setTab] = React.useState<PlanningTab>('map')
+  return (
+    <PlanningTabContext.Provider value={tab}>
+      <SetPlanningTabContext.Provider value={setTab}>
+        {children}
+      </SetPlanningTabContext.Provider>
+    </PlanningTabContext.Provider>
+  )
+}
+
+export const usePlanningTab = () => {
+  const tab = React.useContext(PlanningTabContext)
+  const setTab = React.useContext(SetPlanningTabContext)
+
+  if (tab === null) {
+    throw Error('PlanningTab is not wrapped')
+  }
+
+  const actions = React.useMemo(() => {
+    const a = {
+      open: (value: PlanningTab) => setTab(value),
+      openInfo: () => setTab('info'),
+      openMap: () => setTab('map'),
+      openSchedule: () => setTab('schedule'),
+    }
+
+    return a
+  }, [setTab])
+
+  return [tab, actions] as const
+}


### PR DESCRIPTION
close #178 

- スケジュールの末尾にホテルを設定ボタンを追加
  - ホテル設定の導線を明確にするため
  - ホテルが設定されていないとき かつ 2日以上のスケジュールが定義されている場合にのみ表示
  - ホテル設定後は右下のスピードダイアルで設定する
- ボタンからマップビューへの繊維を簡易化するため、タブ切り替え用のフックを作成した