### PR TITLE
FEAT: Use bff to show gmaps photo that getting base64 encoded string

### DIFF
--- a/src/components/modules/SpotCard.tsx
+++ b/src/components/modules/SpotCard.tsx
@@ -22,7 +22,7 @@ type Props = {
 }
 const SpotCard: React.FC<Props> = ({ spot }) => {
   const placesService = usePlaces()
-  const [photos, setPhotos] = React.useState<Array<string>>([])
+  const [photo, setPhotos] = React.useState<string>('')
 
   const countRef = React.useRef(0)
   React.useEffect(() => {
@@ -30,9 +30,6 @@ const SpotCard: React.FC<Props> = ({ spot }) => {
   }, [])
 
   React.useEffect(() => {
-    if (!placesService.isLoaded) {
-      return
-    }
     if (countRef.current !== 0) {
       return
     }
@@ -45,7 +42,7 @@ const SpotCard: React.FC<Props> = ({ spot }) => {
     }
 
     return () => {
-      setPhotos([])
+      setPhotos('')
     }
   }, [spot.placeId, placesService])
 
@@ -69,7 +66,7 @@ const SpotCard: React.FC<Props> = ({ spot }) => {
               <AddSpotButton
                 newSpot={{
                   ...spot,
-                  imageUrl: photos[0] || '',
+                  imageUrl: '',
                   duration: 60,
                   durationUnit: 'minute',
                 }}
@@ -78,9 +75,9 @@ const SpotCard: React.FC<Props> = ({ spot }) => {
           </CardActions>
         </Grid>
         <Grid item xs={4}>
-          {photos.length > 0 && (
+          {photo.length > 0 && (
             <Image
-              src={photos[0]}
+              src={`data:image/png;base64,${photo}`}
               width={200}
               height={200}
               layout="responsive"

--- a/src/hooks/googlemaps/useDirections.ts
+++ b/src/hooks/googlemaps/useDirections.ts
@@ -55,7 +55,10 @@ export const useDirections = () => {
     ) => {
       try {
         setLoading(true)
-        const result = await post<DirectionsResult<T>>(bffConfigs.url, props)
+        const result = await post<DirectionsResult<T>>(
+          `${bffConfigs.url}/directions`,
+          props
+        )
 
         if (result.route) {
           return result.route

--- a/src/hooks/googlemaps/usePlaces.ts
+++ b/src/hooks/googlemaps/usePlaces.ts
@@ -1,36 +1,28 @@
 import * as React from 'react'
 
-import { PlacesServiceContext } from 'contexts/PlacesServiceProvider'
 import { SpotDTO } from 'components/modules/SpotCard'
+import { useAxios } from 'hooks/axios/useAxios'
+import { bffConfigs } from 'configs'
+import { PlacesServiceContext } from 'contexts/PlacesServiceProvider'
+
+type PlacesPhotoResult = {
+  html_attribute: Array<string>
+  image: string
+}
 
 export const usePlaces = () => {
+  const { post } = useAxios()
   const places = React.useContext(PlacesServiceContext)
 
   const actions = React.useMemo(
     () => ({
-      isLoaded: places !== null,
       getPhotos: async (placeId: string) => {
-        if (places === null) {
-          throw Error('JS Google Map api is not loaded')
-        }
-
-        const photos = await new Promise<Array<string>>((resolve, reject) => {
-          places.getDetails(
-            {
-              placeId,
-              fields: ['photos'],
-            },
-            (result, status) => {
-              if (status !== google.maps.places.PlacesServiceStatus.OK) {
-                reject(new Error('Fail to connect google maps api'))
-              }
-
-              resolve(result?.photos?.map((item) => item.getUrl()) || [])
-            }
-          )
-        })
-
-        return photos
+        const result = await post<PlacesPhotoResult>(
+          `${bffConfigs.url}/places_photos`,
+          { place_id: placeId, max_width: 150, max_height: 150 }
+        )
+        console.log(result)
+        return result.image
       },
       search: async (params: google.maps.places.TextSearchRequest) => {
         if (places === null) {
@@ -58,7 +50,7 @@ export const usePlaces = () => {
         })
       },
     }),
-    [places]
+    [places, post]
   )
 
   return actions


### PR DESCRIPTION
close #182 

- Spot 画像に base64 でエンコードされた画像を使うことにした
  - API キーが Photos URL に含まれていたため
  - BFF で画像を取得、変換するようにした