### PR TITLE
FIX: Update map props on that context instead of google map component…

### DIFF
--- a/src/components/modules/GoogleMap.tsx
+++ b/src/components/modules/GoogleMap.tsx
@@ -9,7 +9,6 @@ import { SetDirectionServiceContext } from 'contexts/DirectionServiceProvider'
 import { SetDistanceMatrixContext } from 'contexts/DistanceMatrixProvider'
 import { SetPlacesServiceContext } from 'contexts/PlacesServiceProvider'
 import { useMapProps } from 'hooks/googlemaps/useMapProps'
-import { useTravelPlan } from 'hooks/useTravelPlan'
 
 const containerStyle = {
   width: '100%',
@@ -32,7 +31,6 @@ const GoogleMap: React.FC<Props> = React.memo(function Map({
     libraries: libs,
     // ...otherOptions
   })
-  const [plan] = useTravelPlan()
 
   const [mapProps, setMapProps] = useMapProps()
 
@@ -76,18 +74,6 @@ const GoogleMap: React.FC<Props> = React.memo(function Map({
     setGoogleMap(mapInstance)
     onLoad?.(mapInstance)
   }
-
-  React.useEffect(() => {
-    // 選択しているプランの目的地を中心にする
-    if (plan?.destination) {
-      const { lat, lng, zoom } = plan.destination
-      setMapProps((prev) => ({
-        ...prev,
-        center: { lat, lng },
-        zoom: zoom,
-      }))
-    }
-  }, [plan?.destination, setMapProps])
 
   if (loadError) {
     console.log('Error has occurred when loading google map')

--- a/src/components/modules/Route.tsx
+++ b/src/components/modules/Route.tsx
@@ -69,7 +69,6 @@ const RouteEvent: React.FC<Props> = ({ origin, dest, onChange }) => {
 
   React.useEffect(() => {
     routesApi.getAndSearch(origin, dest, selected.key).then((result) => {
-      console.log(result)
       setRoute(result)
     })
   }, [dest, origin, routesApi, selected.key])

--- a/src/contexts/MapPropsProvider.tsx
+++ b/src/contexts/MapPropsProvider.tsx
@@ -1,5 +1,7 @@
 import * as React from 'react'
 
+import { useTravelPlan } from 'hooks/useTravelPlan'
+
 const DEFAULT_CENTER = { lat: 36.5941035450526, lng: 138.70038569359122 }
 
 type MapProps = {
@@ -22,6 +24,20 @@ export const MapPropsProvider: React.FC = ({ children }) => {
     bounds: null,
     mounted: false,
   })
+
+  const [plan] = useTravelPlan()
+
+  React.useEffect(() => {
+    // 選択しているプランの目的地を中心にする
+    if (plan?.destination) {
+      const { lat, lng, zoom } = plan.destination
+      setMapProps((prev) => ({
+        ...prev,
+        center: { lat, lng },
+        zoom: zoom,
+      }))
+    }
+  }, [plan?.destination, setMapProps])
 
   return (
     <MapPropsContext.Provider value={mapProps}>

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -37,11 +37,11 @@ const App: React.FC<MyAppProps> = ({
       <ApolloClientProvider>
         <UserAuthorizationProvider>
           <ConfirmationProvider>
-            <DirectionServiceProvider>
-              <DistanceMatrixProvider>
-                <MapPropsProvider>
+            <CurrentPlanContextProvider>
+              <DirectionServiceProvider>
+                <DistanceMatrixProvider>
                   <PlacesServiceProvider>
-                    <CurrentPlanContextProvider>
+                    <MapPropsProvider>
                       <SelectedSpotsProvider>
                         <SpotEditorProvider>
                           <ThemeProvider theme={theme}>
@@ -50,11 +50,11 @@ const App: React.FC<MyAppProps> = ({
                           </ThemeProvider>
                         </SpotEditorProvider>
                       </SelectedSpotsProvider>
-                    </CurrentPlanContextProvider>
+                    </MapPropsProvider>
                   </PlacesServiceProvider>
-                </MapPropsProvider>
-              </DistanceMatrixProvider>
-            </DirectionServiceProvider>
+                </DistanceMatrixProvider>
+              </DirectionServiceProvider>
+            </CurrentPlanContextProvider>
           </ConfirmationProvider>
         </UserAuthorizationProvider>
       </ApolloClientProvider>


### PR DESCRIPTION
close #198 

- Map の表示情報を更新するタイミングを変更
  - 従来は、Map を開くたびに現在のプラン情報から　Center などを更新していた
  - 今回からは Context で制御するようにして、純粋に Plan が入れ替わったときだけデフォルト値を更新するようにした