### PR TITLE
Fix/210 route mode by day

### DIFF
--- a/src/components/modules/Map/SpotsOverlay.tsx
+++ b/src/components/modules/Map/SpotsOverlay.tsx
@@ -47,19 +47,17 @@ const MapOverlay: React.FC<Props> = ({ anySpot, setAnySpot }) => {
   const [routeMode, toggleMode] = useToggle(config.routeMode)
   const [spots, reload] = useSpots()
   const [events] = useEvents()
-  const [schedules] = useSchedules()
+  const [, schedulesApi] = useSchedules()
   const waypoints = React.useMemo(
     () =>
       events
         .map((e) => e.data())
         .sort(
           (a, b) =>
-            (schedules?.docs.find((s) => s.id === a.schedule.id)?.data()
-              .position || 0) -
-            (schedules?.docs.find((s) => s.id === b.schedule.id)?.data()
-              .position || 0)
+            (schedulesApi.get(a.schedule.id)?.data().position || 0) -
+            (schedulesApi.get(b.schedule.id)?.data().position || 0)
         ),
-    [events, schedules?.docs]
+    [events, schedulesApi]
   )
 
   React.useEffect(() => {

--- a/src/components/modules/Map/SpotsOverlay.tsx
+++ b/src/components/modules/Map/SpotsOverlay.tsx
@@ -16,7 +16,7 @@ import SpotCard from '../SpotCard'
 import AnySpotCard from './AnySpotCard'
 import { useSpots } from 'hooks/useSpots'
 import { usePlanViewConfig } from 'contexts/PlanViewConfigProvider'
-import { SpotDTO } from 'hooks/useSchedules'
+import { SpotDTO, useSchedules } from 'hooks/useSchedules'
 import { useEvents } from 'hooks/useEvents'
 
 const polylineOptions = {
@@ -47,7 +47,20 @@ const MapOverlay: React.FC<Props> = ({ anySpot, setAnySpot }) => {
   const [routeMode, toggleMode] = useToggle(config.routeMode)
   const [spots, reload] = useSpots()
   const [events] = useEvents()
-  const waypoints = React.useMemo(() => events.map((e) => e.data()), [events])
+  const [schedules] = useSchedules()
+  const waypoints = React.useMemo(
+    () =>
+      events
+        .map((e) => e.data())
+        .sort(
+          (a, b) =>
+            (schedules?.docs.find((s) => s.id === a.schedule.id)?.data()
+              .position || 0) -
+            (schedules?.docs.find((s) => s.id === b.schedule.id)?.data()
+              .position || 0)
+        ),
+    [events, schedules?.docs]
+  )
 
   React.useEffect(() => {
     setConfig({ routeMode })

--- a/src/hooks/useMove.ts
+++ b/src/hooks/useMove.ts
@@ -11,7 +11,7 @@ type OrderedItem = {
 export const useMove = () => {
   const db = useFirestore()
   const [, eventsApi] = useEvents()
-  const [schedules] = useSchedules()
+  const [schedules, schedulesApi] = useSchedules()
 
   const actions = React.useMemo(() => {
     const a = {
@@ -37,7 +37,7 @@ export const useMove = () => {
       ) => {
         // moving to same list
         // 移動元のイベントを特定するために、Drop された Schedule を特定
-        const schedule = schedules?.docs.find((doc) => doc.id === sourceId)
+        const schedule = schedulesApi.get(sourceId)
         if (!schedule) {
           console.error('Moved source object is not found')
           return
@@ -64,7 +64,7 @@ export const useMove = () => {
 
         // droppableId は Schedule ドキュメントの ID が設定されているので、
         // それを使って移動先の Reference を取得
-        const dest = schedules?.docs.find((doc) => doc.id === destinationId)
+        const dest = schedulesApi.get(destinationId)
         if (!dest) {
           console.error(`schedule ${destinationId} is not found`)
           return
@@ -104,7 +104,7 @@ export const useMove = () => {
     }
 
     return a
-  }, [db, eventsApi, schedules])
+  }, [db, eventsApi, schedules, schedulesApi])
 
   return actions
 }

--- a/src/hooks/useMove.ts
+++ b/src/hooks/useMove.ts
@@ -10,7 +10,7 @@ type OrderedItem = {
 
 export const useMove = () => {
   const db = useFirestore()
-  const [events, eventsApi] = useEvents()
+  const [, eventsApi] = useEvents()
   const [schedules] = useSchedules()
 
   const actions = React.useMemo(() => {

--- a/src/hooks/useSchedules.ts
+++ b/src/hooks/useSchedules.ts
@@ -41,10 +41,13 @@ export const useSchedules = () => {
           return await addDoc(c, newSchedule)
         }
       },
+      get: (id: string) => {
+        return schedules?.docs.find((s) => s.id === id)
+      },
     }
 
     return a
-  }, [planRef])
+  }, [planRef, schedules?.docs])
 
   return [schedules, actions] as const
 }


### PR DESCRIPTION
close #210 

ルートモード使用時にイベントの順序がバラバラ担っていた問題を修正

- ルートモード用のイベント取得時に、イベントのポジションだけでソートしていた
- 何日目かという情報が失われていたため、順序がめちゃくちゃになっていた