### PR TITLE
FIX: Manage the number of schedules to create in hooks to calc positi…

### DIFF
--- a/src/hooks/usePlans.ts
+++ b/src/hooks/usePlans.ts
@@ -115,9 +115,7 @@ export const usePlans = () => {
           const plan = await addDoc(PLANS_SUB_COLLECTIONS(user.uid), newPlan)
 
           // days は宿泊数なので、日程の総数は +1 日
-          Array.from(Array((newPlan.days || 0) + 1)).forEach(() => {
-            schedulesApi.create(plan)
-          })
+          schedulesApi.create(plan, (newPlan.days || 0) + 1)
 
           return plan.id
         } catch (e) {

--- a/src/hooks/useSchedules.ts
+++ b/src/hooks/useSchedules.ts
@@ -31,22 +31,33 @@ export const useSchedules = () => {
 
   const actions = React.useMemo(() => {
     const a = {
-      create: async (planDoc: DocumentReference<Plan>) => {
-        const startDate = dayjs().hour(9).minute(0).second(0)
-        const totalPos = (schedules?.docs || []).reduce(
-          (pos, schedule) => pos + schedule.data().position,
-          1024
-        )
+      /**
+       * 指定した Plan にスケジュール Document を追加する
+       * 連続で追加する場合は引数で指定する
+       * @param planDoc スケジュールを追加する対象の Plan ドキュメント
+       * @param number 作成する数、外から連続で作ろうとするとSchedulesのRefが最新にならないため
+       * @returns
+       */
+      create: async (planDoc: DocumentReference<Plan>, number = 1) => {
+        return Promise.all(
+          Array.from(Array(number)).map(async (_, i) => {
+            const startDate = dayjs().hour(9).minute(0).second(0)
+            // 末尾に追加するため末尾の schedule.position に加算
+            const newPos =
+              (schedules?.docs.slice(-1)[0].data().position || 0) +
+              1024 * (i + 1)
 
-        const newSchedule: ScheduleDTO = {
-          start: startDate.toDate(),
-          end: startDate.hour(19).minute(0).toDate(),
-          size: 0,
-          position: totalPos,
-        }
-        
-        const c = SCHEDULES_SUB_COLLECTIONS(planDoc)
-        return await addDoc(c, newSchedule)
+            const newSchedule: ScheduleDTO = {
+              start: startDate.toDate(),
+              end: startDate.hour(19).minute(0).toDate(),
+              size: 0,
+              position: newPos,
+            }
+
+            const c = SCHEDULES_SUB_COLLECTIONS(planDoc)
+            return await addDoc(c, newSchedule)
+          })
+        )
       },
       get: (id: string) => {
         return schedules?.docs.find((s) => s.id === id)


### PR DESCRIPTION
Close #233

- 新しいプランを作成するときに、Schedule のポジションがすべて1024になる問題を修正
  - Position の計算方法が悪かった
    - 従来: Schedules ドキュメントのすべての Position 値を加算して、+1024
    - これだと、連続で作るときに、メモ化した関数内から最新のスケジュールリストを取ってこれなかった
    - 修正: Schedules を作成するときに作成する個数を指定することにした。
    - これなら、作成時点の最大値 + α で正しい計算ができるようになった